### PR TITLE
Added shrink_script(), along with a test function.

### DIFF
--- a/tests/test_uflash.py
+++ b/tests/test_uflash.py
@@ -481,3 +481,43 @@ def test_extract_command_no_source():
     """
     with pytest.raises(TypeError):
         uflash.extract(None, None)
+
+def test_shrink_script():
+    """
+    shrunk scripts should behave exactly the same as unshrunk scripts,
+    and should not make scripts larger.
+    """
+
+    string1 = ''
+    string2 = ''
+
+    unshrunk_script="""
+    
+output = ''         
+
+for i in range(10):       
+
+    if((i%3==0) and ( i % 5 == 0 )):           
+        output +='!'
+    elif ( i % 3 == 0 ):
+        output +='F'
+    elif (i%5 == 0):
+        output += 'B'
+    else:
+        output += str(i)
+    
+
+    
+    """
+
+    shrunk_script = uflash.shrink_script(unshrunk_script)
+
+    exec unshrunk_script + "\nstring1 = output"
+    exec shrunk_script + "\nstring2 = output"
+    
+    print string1
+    print string2
+    
+    assert string1 == string2
+    assert len(unshrunk_script) >= len(shrunk_script)
+

--- a/tests/test_uflash.py
+++ b/tests/test_uflash.py
@@ -485,7 +485,7 @@ def test_extract_command_no_source():
 def test_shrink_script():
     """
     shrunk scripts should behave exactly the same as unshrunk scripts,
-    and should not make scripts larger.
+    and should be the same size or smaller than unshrunk scripts.
     """
 
     string1 = ''

--- a/uflash.py
+++ b/uflash.py
@@ -157,7 +157,7 @@ def extract_script(embedded_hex):
 
 def shrink_script(script):
     """
-    Takes the byte content of a Pyton script, and attempts to return a
+    Takes the byte content of a Python script, and attempts to return a
     shrunk version of it.
     """
 

--- a/uflash.py
+++ b/uflash.py
@@ -9,6 +9,7 @@ import os
 import struct
 import binascii
 import ctypes
+import re
 from subprocess import check_output
 
 
@@ -60,6 +61,8 @@ def hexlify(script):
     # Convert line endings in case the file was created on Windows.
     script = script.replace(b'\r\n', b'\n')
     script = script.replace(b'\r', b'\n')
+    # Shrink script.
+    script = shrink_script(script)
     # Add header, pad to multiple of 16 bytes.
     data = b'MP' + struct.pack('<H', len(script)) + script
     # Padding with null bytes in a 2/3 compatible way
@@ -150,6 +153,46 @@ def extract_script(embedded_hex):
         return ''
     # Pass the extracted hex through unhexlify
     return unhexlify(blob)
+
+
+def shrink_script(script):
+    """
+    Takes the byte content of a Pyton script, and attempts to return a
+    shrunk version of it.
+    """
+
+    indent_token = "\t"
+    shrunk_py = []
+    stack = [""]
+    line_syntax = re.compile('^(\s*)(.*)')
+    for line in [ l.rstrip() for l in script.split('\n') if l.rstrip() != "" ]:
+
+        # Get the leftmost padding.
+        match_object = line_syntax.match(line)
+        thisline_indents = match_object.group(1)
+
+        # Either it's the same indent level as the previous line, 
+        # one higher indent level than the previous line, or one or more dedents.
+        # Same indent level:
+        if (thisline_indents == stack[-1]):
+            pass
+
+        # One higher indent level:
+        elif ((len(thisline_indents) > len(stack[-1]))
+            and (thisline_indents[:len(stack[-1])] == stack[-1])):
+            stack.append(thisline_indents)
+
+        # One or more dedents:
+        elif (thisline_indents in stack):
+            stack = stack[:(stack.index(thisline_indents)+1)]
+
+        # Otherwise, we don't know about this indentation level, so throw a tantrum.
+        else:
+            raise IndentationError('Inconsistent indentation in user-supplied Python script.')
+
+        shrunk_py.append(indent_token*(len(stack)-1) + match_object.group(2))
+
+    return '\n'.join(shrunk_py)
 
 
 def find_microbit():


### PR DESCRIPTION
shrink_script() attempts to reduce the size of the user-supplied python script by getting rid of superfluous whitespace characters. It is now called in the hexlify() function, just before converting the user-supplied script into its Intel Hex representation.

Note that shrink_script is lossy: scripts that are hexlified then subsequently unhexlified will have exactly the same run-time behaviour, but will not necessarily have the exact same ascii representation. This may affect some of the test functions in test_uflash.py

