### PR TITLE
Extract scripts from non-uflash'd hex files

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,3 @@
 Nicholas H.Tollervey (ntoll@ntoll.org)
 Matt Wheeler (m@funkyhat.org)
-
+L0C4RD (L0C4RD@gmail.com)


### PR DESCRIPTION
extract_script() is extended to be able to handle hex files that haven't necessarily been generated directly by uflash, and have perhaps been produced by other means (e.g. a hex dump via SWD.) It still works identically for uflash-generated hex files.