### PR TITLE
Flash multiple microbits at once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ uflash.egg-info/*
 .coverage
 dist/*
 build/*
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+install: pip install tox-travis
+script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
-install: pip install tox-travis
+install: pip install tox-travis coveralls
 script: tox
+after_success:
+  - coveralls

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,3 @@
 Nicholas H.Tollervey (ntoll@ntoll.org)
 Matt Wheeler (m@funkyhat.org)
-
+Tom Viner (uflash@viner.tv)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Release History
 ===============
 
+1.0.4.dev0
+
+* Add support for flashing multiple microbits.
+
 1.0.3
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,12 @@ second argument to the command::
     $ uflash myscript.py /media/ntoll/MICROBIT
     Flashing Python to: /media/ntoll/MICROBIT/micropython.hex
 
+You can even flash multiple devices at once:
+
+    $ uflash myscript.py /media/ntoll/MICROBIT /media/ntoll/MICROBIT1
+    Flashing Python to: /media/ntoll/MICROBIT/micropython.hex
+    Flashing Python to: /media/ntoll/MICROBIT1/micropython.hex
+
 To extract a Python script from a hex file use the "-e" flag like this::
 
     $ uflash -e something.hex myscript.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ sphinx
 pytest-cov
 
 # Mock is bundled as part of unittest since Python 3.3
-mock ; python_version == '2.7'
+# mock_open can't read binary data in <= 3.4.2
+mock ; python_version == '2.7' or python_version == '3.4'

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Education',
         'Topic :: Software Development :: Embedded Systems',
     ],

--- a/tests/test_uflash.py
+++ b/tests/test_uflash.py
@@ -313,8 +313,8 @@ def test_flash_with_path_to_runtime():
                                  path_to_runtime='tests/fake.hex')
                     assert mock_open.call_args[0][0] == 'tests/fake.hex'
                     assert em_h.call_args[0][0] == b'script'
-                    mock_save.assert_called_once_with('foo',
-                                                      'bar/micropython.hex')
+                    expected_hex_path = os.path.join('bar', 'micropython.hex')
+                    mock_save.assert_called_once_with('foo', expected_hex_path)
 
 
 def test_flash_cannot_find_microbit():

--- a/tests/test_uflash.py
+++ b/tests/test_uflash.py
@@ -197,7 +197,7 @@ def test_find_microbit_unknown_os():
     with mock.patch('os.name', 'foo'):
         with pytest.raises(NotImplementedError) as ex:
             uflash.find_microbit()
-    assert ex.value.args[0] == 'OS not supported.'
+    assert ex.value.args[0] == 'OS "foo" not supported.'
 
 
 def test_save_hex():

--- a/tests/test_uflash.py
+++ b/tests/test_uflash.py
@@ -2,19 +2,20 @@
 """
 Tests for the uflash module.
 """
-import tempfile
-import os
-import sys
-import os.path
 import ctypes
+import os
+import os.path
+import sys
+import tempfile
+
+import pytest
+import uflash
 
 try:
     from unittest import mock
 except ImportError:
     import mock
 
-import pytest
-import uflash
 
 
 if sys.version_info.major == 2:

--- a/tests/test_uflash.py
+++ b/tests/test_uflash.py
@@ -281,13 +281,36 @@ def test_flash_has_python_no_path_to_microbit():
             assert mock_save.call_args[0][1] == expected_path
 
 
+def test_flash_with_path_to_multiple_microbits():
+    """
+    Flash the referenced paths to the micro:bits with a hex file generated from
+    the MicroPython firmware and the referenced Python script.
+    """
+    with mock.patch('uflash.save_hex') as mock_save:
+        uflash.flash('tests/example.py', ['test_path1', 'test_path2'])
+        assert mock_save.call_count == 2
+        # Create the hex we're expecting to flash onto the devices.
+        with open('tests/example.py', 'rb') as py_file:
+            python = uflash.hexlify(py_file.read())
+        assert python
+        expected_hex = uflash.embed_hex(uflash._RUNTIME, python)
+
+        assert mock_save.call_args_list[0][0][0] == expected_hex
+        expected_path = os.path.join('test_path1', 'micropython.hex')
+        assert mock_save.call_args_list[0][0][1] == expected_path
+
+        assert mock_save.call_args_list[1][0][0] == expected_hex
+        expected_path = os.path.join('test_path2', 'micropython.hex')
+        assert mock_save.call_args_list[1][0][1] == expected_path
+
+
 def test_flash_with_path_to_microbit():
     """
     Flash the referenced path to the micro:bit with a hex file generated from
     the MicroPython firmware and the referenced Python script.
     """
     with mock.patch('uflash.save_hex') as mock_save:
-        uflash.flash('tests/example.py', 'test_path')
+        uflash.flash('tests/example.py', ['test_path'])
         assert mock_save.call_count == 1
         # Create the hex we're expecting to flash onto the device.
         with open('tests/example.py', 'rb') as py_file:
@@ -349,7 +372,7 @@ def test_main_no_args():
         with mock.patch('uflash.flash') as mock_flash:
             uflash.main()
             mock_flash.assert_called_once_with(path_to_python=None,
-                                               path_to_microbit=None,
+                                               paths_to_microbits=[],
                                                path_to_runtime=None)
 
 
@@ -361,7 +384,7 @@ def test_main_first_arg_python():
     with mock.patch('uflash.flash') as mock_flash:
         uflash.main(argv=['foo.py'])
         mock_flash.assert_called_once_with(path_to_python='foo.py',
-                                           path_to_microbit=None,
+                                           paths_to_microbits=[],
                                            path_to_runtime=None)
 
 
@@ -393,9 +416,25 @@ def test_main_two_args():
     """
     with mock.patch('uflash.flash', return_value=None) as mock_flash:
         uflash.main(argv=['foo.py', '/media/foo/bar'])
-        mock_flash.assert_called_once_with(path_to_python='foo.py',
-                                           path_to_microbit='/media/foo/bar',
-                                           path_to_runtime=None)
+        mock_flash.assert_called_once_with(
+            path_to_python='foo.py',
+            paths_to_microbits=['/media/foo/bar'],
+            path_to_runtime=None)
+
+
+def test_main_multiple_microbits():
+    """
+    If there are more than two arguments passed into main, then it should pass
+    them onto the flash() function.
+    """
+    with mock.patch('uflash.flash', return_value=None) as mock_flash:
+        uflash.main(argv=[
+            'foo.py', '/media/foo/bar', '/media/foo/baz', '/media/foo/bob'])
+        mock_flash.assert_called_once_with(
+            path_to_python='foo.py',
+            paths_to_microbits=[
+                '/media/foo/bar', '/media/foo/baz', '/media/foo/bob'],
+            path_to_runtime=None)
 
 
 def test_main_runtime():
@@ -405,9 +444,10 @@ def test_main_runtime():
     """
     with mock.patch('uflash.flash') as mock_flash:
         uflash.main(argv=['-r' 'baz.hex', 'foo.py', '/media/foo/bar'])
-        mock_flash.assert_called_once_with(path_to_python='foo.py',
-                                           path_to_microbit='/media/foo/bar',
-                                           path_to_runtime='baz.hex')
+        mock_flash.assert_called_once_with(
+            path_to_python='foo.py',
+            paths_to_microbits=['/media/foo/bar'],
+            path_to_runtime='baz.hex')
 
 
 def test_main_named_args():
@@ -417,7 +457,7 @@ def test_main_named_args():
     with mock.patch('uflash.flash') as mock_flash:
         uflash.main(argv=['-r', 'baz.hex'])
         mock_flash.assert_called_once_with(path_to_python=None,
-                                           path_to_microbit=None,
+                                           paths_to_microbits=[],
                                            path_to_runtime='baz.hex')
 
 
@@ -427,7 +467,7 @@ def test_extract_command():
     """
     with mock.patch('uflash.extract') as mock_extract:
         uflash.main(argv=['-e', 'hex.hex', 'foo.py'])
-        mock_extract.assert_called_once_with('hex.hex', 'foo.py')
+        mock_extract.assert_called_once_with('hex.hex', ['foo.py'])
 
 
 def test_extract_paths():
@@ -464,9 +504,9 @@ def test_extract_command_source_only():
             mock.patch.object(builtins, 'open', mock_o) as mock_open, \
             mock.patch.object(builtins, 'print') as mock_print:
         uflash.main(argv=['-e', 'hex.hex'])
-        mock_open.assert_called_once_with('hex.hex', 'r')
+        mock_open.assert_any_call('hex.hex', 'r')
         mock_extract_script.assert_called_once_with('script')
-        mock_print.assert_called_once_with(b'print("hello, world!")')
+        mock_print.assert_any_call(b'print("hello, world!")')
 
 
 def test_extract_command_no_source():

--- a/tox.ini
+++ b/tox.ini
@@ -5,4 +5,6 @@ envlist = py27, py33, py34, py35
 commands = py.test {posargs:tests/}
 deps =
     pytest
-    mock
+    # Mock is bundled as part of unittest since Python 3.3
+    # mock_open can't read binary data in < 3.4.3
+    py{27,34}: mock

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35
+envlist = py27, py33, py34, py35, lint
 
 [testenv]
 commands = py.test {posargs:tests/}
@@ -8,3 +8,11 @@ deps =
     # Mock is bundled as part of unittest since Python 3.3
     # mock_open can't read binary data in < 3.4.3
     py{27,34}: mock
+
+[testenv:lint]
+commands =
+    pyflakes setup.py uflash.py tests/
+    pep8 setup.py uflash.py tests/
+deps =
+    pyflakes
+    pep8

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py27, py33, py34, py35
+
+[testenv]
+commands = py.test {posargs:tests/}
+deps =
+    pytest
+    mock

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,11 @@
 envlist = py27, py33, py34, py35, lint
 
 [testenv]
-commands = py.test {posargs:tests/}
+commands = py.test --cov-report term-missing --cov=uflash {posargs:tests/}
 deps =
     pytest
+    pytest-cov
+    coveralls
     # Mock is bundled as part of unittest since Python 3.3
     # mock_open can't read binary data in < 3.4.3
     py{27,34}: mock

--- a/uflash.py
+++ b/uflash.py
@@ -4,14 +4,14 @@ This module contains functions for turning a Python script into a .hex file
 and flashing it onto a BBC micro:bit.
 """
 from __future__ import print_function
+
 import argparse
-import sys
-import os
-import struct
 import binascii
 import ctypes
+import os
+import struct
+import sys
 from subprocess import check_output
-
 
 #: The magic start address in flash memory for a Python script.
 _SCRIPT_ADDR = 0x3e000

--- a/uflash.py
+++ b/uflash.py
@@ -3,6 +3,7 @@
 This module contains functions for turning a Python script into a .hex file
 and flashing it onto a BBC micro:bit.
 """
+from __future__ import print_function
 import argparse
 import sys
 import os

--- a/uflash.py
+++ b/uflash.py
@@ -194,7 +194,7 @@ def find_microbit():
                 return path
     else:
         # No support for unknown operating systems.
-        raise NotImplementedError('OS not supported.')
+        raise NotImplementedError('OS "{}" not supported.'.format(os.name))
 
 
 def save_hex(hex_file, path):


### PR DESCRIPTION
Fix for https://github.com/ntoll/uflash/issues/18 **Flash multiple microbits at once**

The `target` argument can now occur any number of times. 

```bash
$ uflash --help
usage: uflash [-h] [-r RUNTIME] [-e] [source] [target [target ...]]
```

i.e.

```bash
$ uflash setup.py /media/tom/MICROBIT /media/tom/MICROBIT1
Flashing Python to: /media/tom/MICROBIT/micropython.hex
Flashing Python to: /media/tom/MICROBIT1/micropython.hex
```

On Linux this allows shell expansions like:

```bash
$ uflash setup.py /media/tom/MICROBIT*
Flashing Python to: /media/tom/MICROBIT/micropython.hex
Flashing Python to: /media/tom/MICROBIT1/micropython.hex
```

or

```bash
$ uflash setup.py /media/tom/MICROBIT{,3,5}
Flashing Python to: /media/tom/MICROBIT/micropython.hex
Flashing Python to: /media/tom/MICROBIT3/micropython.hex
Flashing Python to: /media/tom/MICROBIT5/micropython.hex
```

Note: uflash does not receive (and cannot deal with) strings like `/media/tom/MICROBIT*`, rather shell expansion takes place, so the actual args passed into the script are `/media/tom/MICROBIT /media/tom/MICROBIT1`.

Windows doesn't do shell expansion, and even the `glob` module cannot reference multiple volumes, i.e. `glob.glob('*:\\MICROBIT')` never matches anything. So on Windows, one must pass n paths for n microbits. And the docs update shows just this - no `*` or `{}`.

Full list of changes:
- Run tests via tox - to test against Pythons 2.7, 3.3, 3.4 & 3.5.
- Add travis-ci config (you'll have to [configure this](https://travis-ci.org/profile/ntoll) if you'd like this setup for this repo @ntoll)
- Fix broken 'print' test on Python 2.7
- Improve unsupported OS error message - name the OS
- Update Authors file
- Isort - re-order imports
- Use `mock.mock_open` rather than a load of `__enter__` `__exit__` mocking
- Fix tests for Windows - `/` v `\` 
- Add linting to tox (your `make pyflakes / pep8` commands are broken btw - I couldn't workout how to fix them without just listing the files we want, which is what I've done in `tox.ini`)
- Add pytest-cov and coveralls config (again @ntoll, if you want it, you'll need to turn it on. [Go here](https://coveralls.io/repos/new). You'll probably want to turn the emails off.)
- Add support for passing multiple microbit paths
- Update docs
- Update changelog

Happy to alter / take any of these changes out, if they don't seem appropriate. Everything is in separate commits.

If you'd like Appveyor to run the tests on Windows automatically, I can add that too (in a separate PR).