### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/uflash.py
+++ b/uflash.py
@@ -27,7 +27,7 @@ will flash the unmodified MicroPython firmware onto the device. Use the -e flag
 to recover a Python script from a hex file. Use the -r flag to specify a custom
 version of the MicroPython runtime.
 
-Documentation is here: http://uflash.readthedocs.org/en/latest/
+Documentation is here: https://uflash.readthedocs.io/en/latest/
 """
 
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.