### PR TITLE
Fix test where pytest version detection was mocked.

### DIFF
--- a/tests/test_uflash.py
+++ b/tests/test_uflash.py
@@ -359,8 +359,8 @@ def test_flash_wrong_python():
     Python 3.
     """
     for version in [(2, 6, 3), (3, 2, 0)]:
-        with mock.patch('sys.version_info', version):
-            with pytest.raises(RuntimeError) as ex:
+        with pytest.raises(RuntimeError) as ex:
+            with mock.patch('sys.version_info', version):
                 uflash.flash()
             assert 'Will only run on Python ' in ex.value.args[0]
 


### PR DESCRIPTION
It doesn't really seem like a platform specific issue, but I am surprised you haven't encountered this before. When I was trying to run the py.test scripts on Windows with Py3.5 I got the following:

```
(py35ubitupython) E:\workspaces\git\microbit\uflash_mine_>python -m pytest
============================= test session starts =============================
platform win32 -- Python 3.5.2, pytest-3.0.4, py-1.4.31, pluggy-0.4.0
rootdir: E:\workspaces\git\microbit\uflash_mine_, inifile:
plugins: cov-2.4.0
collected 40 items

tests\test_uflash.py ........................F...............

================================== FAILURES ===================================
___________________________ test_flash_wrong_python ___________________________

    def test_flash_wrong_python():
        """
        Ensures a call to flash will fail if it's not reported that we're using
        Python 3.
        """
        for version in [(2, 6, 3), (3, 2, 0)]:
            with mock.patch('sys.version_info', version):
                with pytest.raises(RuntimeError) as ex:
>                   uflash.flash()

tests\test_uflash.py:364:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

path_to_python = None, paths_to_microbits = None, path_to_runtime = None

    def flash(path_to_python=None, paths_to_microbits=None, path_to_runtime=None
        """
        Given a path to a Python file will attempt to create a hex file and then
        flash it onto the referenced BBC micro:bit.

        If the path_to_python is unspecified it will simply flash the unmodified
        MicroPython runtime onto the device.

        If paths_to_microbits is unspecified it will attempt to find the device'
        path on the filesystem automatically.

        If the path_to_runtime is unspecified it will use the built in version o
        the MicroPython runtime. This feature is useful if a custom build of
        MicroPython is available.

        If the automatic discovery fails, then it will raise an IOError.
        """
        # Check for the correct version of Python.
        if not ((sys.version_info[0] == 3 and sys.version_info[1] >= 3) or
                (sys.version_info[0] == 2 and sys.version_info[1] >= 7)):
>           raise RuntimeError('Will only run on Python 2.7, or 3.3 and later.')
E           RuntimeError: Will only run on Python 2.7, or 3.3 and later.

uflash.py:251: RuntimeError

During handling of the above exception, another exception occurred:

    def test_flash_wrong_python():
        """
        Ensures a call to flash will fail if it's not reported that we're using
        Python 3.
        """
        for version in [(2, 6, 3), (3, 2, 0)]:
            with mock.patch('sys.version_info', version):
                with pytest.raises(RuntimeError) as ex:
>                   uflash.flash()
E                   AttributeError: module 'sys' has no attribute 'exc_clear'

tests\test_uflash.py:364: AttributeError
===================== 1 failed, 39 passed in 0.40 seconds =====================
```

Looking at the pytest source code it seems like `pytest.raises` manually triggers the Python2 only `sys.exc_clear()` under Python 2.
https://github.com/pytest-dev/pytest/blob/3c81f83602e5fa38cb6187dfc7b131ed88bf8b7d/_pytest/python.py#L1245

So in this case, because we were mocking the sys version py.test was tricked into thinking it is running in Python 2 and causes the issue above.