### PR TITLE
Non zero exit code in case of errors (issue #36)

### DIFF
--- a/tests/test_uflash.py
+++ b/tests/test_uflash.py
@@ -457,10 +457,11 @@ def test_main_first_arg_version():
 def test_main_first_arg_not_python():
     """
     If the first argument does not end in ".py" then it should display a useful
-    error message.
+    error message and exit.
     """
     with mock.patch.object(builtins, 'print') as mock_print:
-        uflash.main(argv=['foo.bar'])
+        with pytest.raises(SystemExit):
+            uflash.main(argv=['foo.bar'])
         error = mock_print.call_args[0][0]
         assert isinstance(error, ValueError)
         assert error.args[0] == 'Python files must end in ".py".'
@@ -626,3 +627,9 @@ def test_watch_file(mock_os, mock_time):
     mock_os.path.getmtime.return_value = 2  # Simulate file change
     t.join()
     assert call_count[0] == 2
+
+
+@mock.patch('uflash.flash', side_effect=RuntimeError('Flashing failed!'))
+def test_non_zero_exit_code_on_exception(mock_flash):
+    with pytest.raises(SystemExit):
+        uflash.main()

--- a/uflash.py
+++ b/uflash.py
@@ -372,6 +372,7 @@ def main(argv=None):
     except Exception as ex:
         # The exception of no return. Print the exception information.
         print(ex)
+        sys.exit(1)
 
 
 #: A string representation of the MicroPython runtime hex.


### PR DESCRIPTION
Apart from adding this feature there are a few changes to the tests. I couldn't just implement the feature without solving them first.
I found silent failures in the tests as the result of the "catch all" block with the `print` in the `main` function. These issue were solved (not very elegantly, but with less mocking) in the first commit in this PR. Here are the problems I found:

- In `test_main_first_arg_help`, mocking argparse cause it not to raise `SystemExit` as it usually does when called with `--help`. So, the code continues and fails in `extract`. This failure is ignored. In addition, the test didn't checked anything related to the functionallity of the `--help` flag.

- In `test_main_first_arg_version`, argparse failed as it type checks the arguments and `'%(prog)s ' + get_version()` is a mock instead of an expected string. The failure (`TypeError`), again, was ignored. And again, the test checked almost nothing relevant.

I think that the rest of this PR is strightforward. Please ask if more elaboration needed.