### PR TITLE
Make consistent with mu editor version - this version causes an AttributeError exception

### DIFF
--- a/uflash.py
+++ b/uflash.py
@@ -66,9 +66,7 @@ def hexlify(script):
     data = b'MP' + struct.pack('<H', len(script)) + script
     # Padding with null bytes in a 2/3 compatible way
     data = data + (b'\x00' * (16 - len(data) % 16))
-    if len(data) > 8192:
-        # 'MP' = 2 bytes, script length is another 2 bytes.
-        raise ValueError("Python script must be less than 8188 bytes.")
+    assert len(data) <= 0x2000
     # Convert to .hex format.
     output = [':020000040003F7']  # extended linear address, 0x0003.
     addr = _SCRIPT_ADDR


### PR DESCRIPTION
I have a very simple program:
```
from microbit import *

pin0.set_pull(pin0.PULL_UP)
```
Flashing from mu causes no errors, but flashing from the code in this distribution, I get:
```
  File "__main__", line 3, in <module>
AttributeError: 'MicroBitTouchPin' object has no attribute 'set_pull'

```
Both uflash.py in this repo and in mu contain the same version number, yet when I do a file compare, I get the following differences:

From mu:
```
def hexlify(script):
    """
    Takes the byte content of a Python script and returns a hex encoded
    version of it.

    Based on the hexlify script in the microbit-micropython repository.
    """
    if not script:
        return ''
    # Convert line endings in case the file was created on Windows.
    script = script.replace(b'\r\n', b'\n')
    script = script.replace(b'\r', b'\n')
    # Add header, pad to multiple of 16 bytes.
    data = b'MP' + struct.pack('<H', len(script)) + script
    # Padding with null bytes in a 2/3 compatible way
    data = data + (b'\x00' * (16 - len(data) % 16))
   # -----> different from below
    assert len(data) <= 0x2000
```

From this repo:
```
def hexlify(script):
    """
    Takes the byte content of a Python script and returns a hex encoded
    version of it.

    Based on the hexlify script in the microbit-micropython repository.
    """
    if not script:
        return ''
    # Convert line endings in case the file was created on Windows.
    script = script.replace(b'\r\n', b'\n')
    script = script.replace(b'\r', b'\n')
    # Add header, pad to multiple of 16 bytes.
    data = b'MP' + struct.pack('<H', len(script)) + script
    # Padding with null bytes in a 2/3 compatible way
    data = data + (b'\x00' * (16 - len(data) % 16))
   # ------> different from above
    if len(data) > 8192:
        # 'MP' = 2 bytes, script length is another 2 bytes.
        raise ValueError("Python script must be less than 8188 bytes.")
```
Please note that I did not change the version number, which will keep it consistent with the mu version  version number.