### PR TITLE
Ignore network drives

### DIFF
--- a/tests/test_uflash.py
+++ b/tests/test_uflash.py
@@ -212,6 +212,11 @@ def test_find_microbit_nt_exists():
     mock_windll.kernel32 = mock.MagicMock()
     mock_windll.kernel32.GetVolumeInformationW = mock.MagicMock()
     mock_windll.kernel32.GetVolumeInformationW.return_value = None
+    #
+    # Have every drive claim to be removable
+    #
+    mock_windll.kernel32.GetDriveTypeW = mock.MagicMock()
+    mock_windll.kernel32.GetDriveTypeW.return_value = 2
     with mock.patch('os.name', 'nt'):
         with mock.patch('os.path.exists', return_value=True):
             return_value = ctypes.create_unicode_buffer('MICROBIT')

--- a/uflash.py
+++ b/uflash.py
@@ -243,6 +243,11 @@ def find_microbit():
         try:
             for disk in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ':
                 path = '{}:\\'.format(disk)
+                #
+                # Don't bother looking if the drive isn't removable
+                #
+                if ctypes.windll.kernel32.GetDriveTypeW(path) != 2:
+                    continue
                 if (os.path.exists(path) and
                         get_volume_name(path) == 'MICROBIT'):
                     return path


### PR DESCRIPTION
Before looking for the characteristic "MICROBIT" drive name, check first that the drive is removable. This avoid delays due to disconnected network drives