### PR TITLE
Make save_hex() blocking until micro:bit file transfer finishes.

### DIFF
--- a/tests/test_uflash.py
+++ b/tests/test_uflash.py
@@ -304,6 +304,28 @@ def test_save_hex():
         assert written_file.read() == hex_file
 
 
+def test_save_hex_to_microbit():
+    """
+    Ensure the good case works saving to a location like the micro:bit drive.
+    """
+    # Ensure we have a temporary file to write to that doesn't already exist.
+    path_to_hex = os.path.join(tempfile.gettempdir(), 'microbit.hex')
+    if os.path.exists(path_to_hex):
+        os.remove(path_to_hex)
+    assert not os.path.exists(path_to_hex)
+    # Create the hex file we want to "flash"
+    python = uflash.hexlify(TEST_SCRIPT)
+    hex_file = uflash.embed_hex(uflash._RUNTIME, python)
+    # Save the hex.
+    with mock.patch('os.path.isfile', side_effect=(True, True, False)):
+        with mock.patch('time.time', side_effect=(1, 2, 10)):
+            uflash.save_hex(hex_file, path_to_hex)
+    # Ensure the hex has been written as expected.
+    assert os.path.exists(path_to_hex)
+    with open(path_to_hex) as written_file:
+        assert written_file.read() == hex_file
+
+
 def test_save_hex_no_hex():
     """
     The function raises a ValueError if no hex content is provided.

--- a/tests/test_uflash.py
+++ b/tests/test_uflash.py
@@ -304,28 +304,6 @@ def test_save_hex():
         assert written_file.read() == hex_file
 
 
-def test_save_hex_to_microbit():
-    """
-    Ensure the good case works saving to a location like the micro:bit drive.
-    """
-    # Ensure we have a temporary file to write to that doesn't already exist.
-    path_to_hex = os.path.join(tempfile.gettempdir(), 'microbit.hex')
-    if os.path.exists(path_to_hex):
-        os.remove(path_to_hex)
-    assert not os.path.exists(path_to_hex)
-    # Create the hex file we want to "flash"
-    python = uflash.hexlify(TEST_SCRIPT)
-    hex_file = uflash.embed_hex(uflash._RUNTIME, python)
-    # Save the hex.
-    with mock.patch('os.path.isfile', side_effect=(True, True, False)):
-        with mock.patch('time.time', side_effect=(1, 2, 10)):
-            uflash.save_hex(hex_file, path_to_hex)
-    # Ensure the hex has been written as expected.
-    assert os.path.exists(path_to_hex)
-    with open(path_to_hex) as written_file:
-        assert written_file.read() == hex_file
-
-
 def test_save_hex_no_hex():
     """
     The function raises a ValueError if no hex content is provided.

--- a/uflash.py
+++ b/uflash.py
@@ -282,22 +282,10 @@ def save_hex(hex_file, path):
         raise ValueError('Cannot flash an empty .hex file.')
     if not path.endswith('.hex'):
         raise ValueError('The path to flash must be for a .hex file.')
-    start_time = time.time()
     with open(path, 'wb') as output:
         output.write(hex_file.encode('ascii'))
-    # Determine if hex is copied to a micro:bit if this DAPLink file exists
-    if os.path.isfile(os.path.join(os.path.dirname(path), 'DETAILS.TXT')):
-        # Normally file operations are blocking, but in Linux and macOS they
-        # return before the OS has fully transferred the file to the micro:bit.
-        # To check if the file transfer has finished we wait for the MICROBIT
-        # drive to unmount. Until that happens the hex file will be visible.
-        # In old versions of micro:bit firmware (DAPLink v0234) we need to wait
-        # a bit before the hex file appears. Normal hex transfers of this size
-        # will always take longer than 5 seconds, so wait before checking.
-        while (start_time + 5) > time.time():
-            time.sleep(1)
-        while os.path.isfile(path):
-            time.sleep(0.5)
+        output.flush()
+        os.fsync(output.fileno())
 
 
 def flash(path_to_python=None, paths_to_microbits=None,


### PR DESCRIPTION
This should block save_hex() until the hex file has been fully transfer to the micro:bit in all operating systems.

It would resolve this issue in Mu: https://github.com/mu-editor/mu/issues/1181
And will help simplify the mu.modes.microbit.flash() method as well, not having to have a special case for macOS/Linux.