### PR TITLE
Add Black and format the Python code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 XARGS := xargs -0 $(shell test $$(uname) = Linux && echo -r)
 GREP_T_FLAG := $(shell test $$(uname) = Linux && echo -T)
+BLACK_INSTALLED := $(shell python -m black --version 2>/dev/null)
 
 all:
 	@echo "\nThere is no default Makefile target right now. Try:\n"
@@ -32,7 +33,7 @@ pyflakes:
 	find . \( -name _build -o -name var -o -path ./docs \) -type d -prune -o -name '*.py' -print0 | $(XARGS) pyflakes
 
 pep8: clean
-	find . \( -name _build -o -name var \) -type d -prune -o -name '*.py' -print0 | $(XARGS) -n 1 pycodestyle --repeat --exclude=build/*,docs/* --ignore=E731,E402,W504
+	find . \( -name _build -o -name var \) -type d -prune -o -name '*.py' -print0 | $(XARGS) -n 1 pycodestyle --repeat --exclude=build/*,docs/* --ignore=E731,E402,W504,W503,E203
 
 test: clean
 	py.test
@@ -40,7 +41,21 @@ test: clean
 coverage: clean
 	py.test --cov-report term-missing --cov=uflash tests/
 
-check: clean pep8 pyflakes coverage
+tidy:
+ifdef BLACK_INSTALLED
+	python -m black -l79 .
+else
+	@echo Black not present
+endif
+
+black:
+ifdef BLACK_INSTALLED
+	python -m black --check -l79 .
+else
+	@echo Black not present
+endif
+
+check: clean pep8 pyflakes black coverage
 
 package: check
 	python setup.py sdist

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,40 +20,40 @@ import shlex
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath(".."))
 import uflash
 
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+# needs_sphinx = '1.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.viewcode',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The encoding of source files.
-#source_encoding = 'utf-8-sig'
+# source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = 'uFlash'
-copyright = '2015, Nicholas H.Tollervey'
-author = 'Nicholas H.Tollervey'
+project = "uFlash"
+copyright = "2015, Nicholas H.Tollervey"
+author = "Nicholas H.Tollervey"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -73,37 +73,37 @@ language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
+# today_fmt = '%B %d, %Y'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ["_build"]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#default_role = None
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
-#show_authors = False
+# show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+# modindex_common_prefix = []
 
 # If true, keep warnings as "system message" paragraphs in the built documents.
-#keep_warnings = False
+# keep_warnings = False
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -113,156 +113,155 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'alabaster'
+html_theme = "alabaster"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+# html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+# html_logo = None
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = None
+# html_favicon = None
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+# html_extra_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+# html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+# html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
-#html_domain_indices = True
+# html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+# html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+# html_show_sourcelink = True
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
+# html_show_sphinx = True
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-#html_show_copyright = True
+# html_show_copyright = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
+# html_file_suffix = None
 
 # Language to be used for generating the HTML full-text search index.
 # Sphinx supports the following languages:
 #   'da', 'de', 'en', 'es', 'fi', 'fr', 'h', 'it', 'ja'
 #   'nl', 'no', 'pt', 'ro', 'r', 'sv', 'tr'
-#html_search_language = 'en'
+# html_search_language = 'en'
 
 # A dictionary with options for the search language support, empty by default.
 # Now only 'ja' uses this config value
-#html_search_options = {'type': 'default'}
+# html_search_options = {'type': 'default'}
 
 # The name of a javascript file (relative to the configuration directory) that
 # implements a search results scorer. If empty, the default will be used.
-#html_search_scorer = 'scorer.js'
+# html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'uFlashdoc'
+htmlhelp_basename = "uFlashdoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
-
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
-
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
-
-# Latex figure (float) alignment
-#'figure_align': 'htbp',
+    # The paper size ('letterpaper' or 'a4paper').
+    #'papersize': 'letterpaper',
+    # The font size ('10pt', '11pt' or '12pt').
+    #'pointsize': '10pt',
+    # Additional stuff for the LaTeX preamble.
+    #'preamble': '',
+    # Latex figure (float) alignment
+    #'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'uFlash.tex', 'uFlash Documentation',
-   'Nicholas H.Tollervey', 'manual'),
+    (
+        master_doc,
+        "uFlash.tex",
+        "uFlash Documentation",
+        "Nicholas H.Tollervey",
+        "manual",
+    ),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = None
+# latex_logo = None
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+# latex_use_parts = False
 
 # If true, show page references after internal links.
-#latex_show_pagerefs = False
+# latex_show_pagerefs = False
 
 # If true, show URL addresses after external links.
-#latex_show_urls = False
+# latex_show_urls = False
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
-#latex_domain_indices = True
+# latex_domain_indices = True
 
 
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'uflash', 'uFlash Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, "uflash", "uFlash Documentation", [author], 1)]
 
 # If true, show URL addresses after external links.
-#man_show_urls = False
+# man_show_urls = False
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -271,22 +270,28 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'uFlash', 'uFlash Documentation',
-   author, 'uFlash', 'One line description of project.',
-   'Miscellaneous'),
+    (
+        master_doc,
+        "uFlash",
+        "uFlash Documentation",
+        author,
+        "uFlash",
+        "One line description of project.",
+        "Miscellaneous",
+    ),
 ]
 
 # Documents to append as an appendix to all manuals.
-#texinfo_appendices = []
+# texinfo_appendices = []
 
 # If false, no module index is generated.
-#texinfo_domain_indices = True
+# texinfo_domain_indices = True
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
-#texinfo_show_urls = 'footnote'
+# texinfo_show_urls = 'footnote'
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
-#texinfo_no_detailmenu = False
+# texinfo_no_detailmenu = False
 
 
 # -- Options for Epub output ----------------------------------------------
@@ -298,62 +303,62 @@ epub_publisher = author
 epub_copyright = copyright
 
 # The basename for the epub file. It defaults to the project name.
-#epub_basename = project
+# epub_basename = project
 
 # The HTML theme for the epub output. Since the default themes are not optimized
 # for small screen space, using the same theme for HTML and epub output is
 # usually not wise. This defaults to 'epub', a theme designed to save visual
 # space.
-#epub_theme = 'epub'
+# epub_theme = 'epub'
 
 # The language of the text. It defaults to the language option
 # or 'en' if the language is not set.
-#epub_language = ''
+# epub_language = ''
 
 # The scheme of the identifier. Typical schemes are ISBN or URL.
-#epub_scheme = ''
+# epub_scheme = ''
 
 # The unique identifier of the text. This can be a ISBN number
 # or the project homepage.
-#epub_identifier = ''
+# epub_identifier = ''
 
 # A unique identification for the text.
-#epub_uid = ''
+# epub_uid = ''
 
 # A tuple containing the cover image and cover page html template filenames.
-#epub_cover = ()
+# epub_cover = ()
 
 # A sequence of (type, uri, title) tuples for the guide element of content.opf.
-#epub_guide = ()
+# epub_guide = ()
 
 # HTML files that should be inserted before the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
-#epub_pre_files = []
+# epub_pre_files = []
 
 # HTML files shat should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
-#epub_post_files = []
+# epub_post_files = []
 
 # A list of files that should not be packed into the epub file.
-epub_exclude_files = ['search.html']
+epub_exclude_files = ["search.html"]
 
 # The depth of the table of contents in toc.ncx.
-#epub_tocdepth = 3
+# epub_tocdepth = 3
 
 # Allow duplicate toc entries.
-#epub_tocdup = True
+# epub_tocdup = True
 
 # Choose between 'default' and 'includehidden'.
-#epub_tocscope = 'default'
+# epub_tocscope = 'default'
 
 # Fix unsupported image types using the Pillow.
-#epub_fix_images = False
+# epub_fix_images = False
 
 # Scale large images.
-#epub_max_image_width = 0
+# epub_max_image_width = 0
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
-#epub_show_urls = 'inline'
+# epub_show_urls = 'inline'
 
 # If false, no index is generated.
-#epub_use_index = True
+# epub_use_index = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,11 @@ pyflakes
 coverage
 sphinx
 pytest-cov
-nudatus>=0.0.2 
+nudatus>=0.0.2
 
 # Mock is bundled as part of unittest since Python 3.3
 # mock_open can't read binary data in <= 3.4.2
 mock ; python_version == '2.7' or python_version == '3.4'
+
+# Black is only available for Python 3.6+
+black>=19.10b0;python_version>'3.5'

--- a/setup.py
+++ b/setup.py
@@ -3,39 +3,39 @@ from setuptools import setup
 from uflash import get_version
 
 
-with open('README.rst') as f:
+with open("README.rst") as f:
     readme = f.read()
-with open('CHANGES.rst') as f:
+with open("CHANGES.rst") as f:
     changes = f.read()
 
 
 setup(
-    name='uflash',
+    name="uflash",
     version=get_version(),
-    description='A module and utility to flash Python onto the BBC micro:bit.',
-    long_description=readme + '\n\n' + changes,
-    author='Nicholas H.Tollervey',
-    author_email='ntoll@ntoll.org',
-    url='https://github.com/ntoll/uflash',
-    py_modules=['uflash', 'py2hex'],
-    license='MIT',
+    description="A module and utility to flash Python onto the BBC micro:bit.",
+    long_description=readme + "\n\n" + changes,
+    author="Nicholas H.Tollervey",
+    author_email="ntoll@ntoll.org",
+    url="https://github.com/ntoll/uflash",
+    py_modules=["uflash", "py2hex"],
+    license="MIT",
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Environment :: Console',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Education',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: POSIX',
-        'Operating System :: Microsoft :: Windows',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Topic :: Education',
-        'Topic :: Software Development :: Embedded Systems',
+        "Development Status :: 4 - Beta",
+        "Environment :: Console",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Education",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: POSIX",
+        "Operating System :: Microsoft :: Windows",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: Education",
+        "Topic :: Software Development :: Embedded Systems",
     ],
     entry_points={
-        'console_scripts': ['uflash=uflash:main', 'py2hex=uflash:py2hex'],
-    }
+        "console_scripts": ["uflash=uflash:main", "py2hex=uflash:py2hex"],
+    },
 )

--- a/tests/test_uflash.py
+++ b/tests/test_uflash.py
@@ -28,109 +28,113 @@ TEST_SCRIPT = b"""from microbit import *
 
 display.scroll('Hello, World!')
 """
-TEST_SCRIPT_HEXLIFIED = ':020000040003F7\n' \
-    ':10E000004D50380066726F6D206D6963726F626982\n' \
-    ':10E010007420696D706F7274202A0A0A64697370C3\n' \
-    ':10E020006C61792E7363726F6C6C282748656C6C19\n' \
-    ':10E030006F2C20576F726C642127290A00000000A2'
+TEST_SCRIPT_HEXLIFIED = (
+    ":020000040003F7\n"
+    ":10E000004D50380066726F6D206D6963726F626982\n"
+    ":10E010007420696D706F7274202A0A0A64697370C3\n"
+    ":10E020006C61792E7363726F6C6C282748656C6C19\n"
+    ":10E030006F2C20576F726C642127290A00000000A2"
+)
 
-TEST_SCRIPT_FS = b'This is a slightly longer bit of test that ' \
-    b'should be more than a single block\nThis is a slightly longer bit of ' \
-    b'test that should be more than a single block'
+TEST_SCRIPT_FS = (
+    b"This is a slightly longer bit of test that "
+    b"should be more than a single block\nThis is a slightly longer bit of "
+    b"test that should be more than a single block"
+)
 TEST_SCRIPT_FS_V1_HEX_LIST = [
-    ':020000040003F7',
-    ':108C0000FE26076D61696E2E70795468697320695C',
-    ':108C100073206120736C696768746C79206C6F6E67',
-    ':108C200067657220626974206F66207465737420B2',
-    ':108C3000746861742073686F756C64206265206D60',
-    ':108C40006F7265207468616E20612073696E676C55',
-    ':108C50006520626C6F636B0A5468697320697320C6',
-    ':108C60006120736C696768746C79206C6F6E6765DE',
-    ':108C70007220626974206F662074657374207402B8',
-    ':108C8000016861742073686F756C64206265206D83',
-    ':108C90006F7265207468616E20612073696E676C05',
-    ':108CA0006520626C6F636BFFFFFFFFFFFFFFFFFF3D',
-    ':108CB000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC4',
-    ':108CC000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB4',
-    ':108CD000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA4',
-    ':108CE000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF94',
-    ':108CF000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF84',
-    ':01F80000FD0A',
+    ":020000040003F7",
+    ":108C0000FE26076D61696E2E70795468697320695C",
+    ":108C100073206120736C696768746C79206C6F6E67",
+    ":108C200067657220626974206F66207465737420B2",
+    ":108C3000746861742073686F756C64206265206D60",
+    ":108C40006F7265207468616E20612073696E676C55",
+    ":108C50006520626C6F636B0A5468697320697320C6",
+    ":108C60006120736C696768746C79206C6F6E6765DE",
+    ":108C70007220626974206F662074657374207402B8",
+    ":108C8000016861742073686F756C64206265206D83",
+    ":108C90006F7265207468616E20612073696E676C05",
+    ":108CA0006520626C6F636BFFFFFFFFFFFFFFFFFF3D",
+    ":108CB000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC4",
+    ":108CC000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB4",
+    ":108CD000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA4",
+    ":108CE000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF94",
+    ":108CF000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF84",
+    ":01F80000FD0A",
 ]
 TEST_SCRIPT_FS_V1_HEX_PADDING_LIST = [
-    ':1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4',
-    ':1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4',
-    ':1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4',
-    ':1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4',
-    ':1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4',
-    ':1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4',
-    ':0700000CFFFFFFFFFFFFFFF4',
+    ":1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4",
+    ":1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4",
+    ":1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4",
+    ":1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4",
+    ":1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4",
+    ":1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4",
+    ":0700000CFFFFFFFFFFFFFFF4",
 ]
 TEST_SCRIPT_FS_V2_HEX_LIST = [
-    ':020000040006F4',
-    ':10D0000DFE26076D61696E2E70795468697320690B',
-    ':10D0100D73206120736C696768746C79206C6F6E16',
-    ':10D0200D67657220626974206F6620746573742061',
-    ':10D0300D746861742073686F756C64206265206D0F',
-    ':10D0400D6F7265207468616E20612073696E676C04',
-    ':10D0500D6520626C6F636B0A546869732069732075',
-    ':10D0600D6120736C696768746C79206C6F6E67658D',
-    ':10D0700D7220626974206F66207465737420740267',
-    ':10D0800D016861742073686F756C64206265206D32',
-    ':10D0900D6F7265207468616E20612073696E676CB4',
-    ':10D0A00D6520626C6F636BFFFFFFFFFFFFFFFFFFEC',
-    ':10D0B00DFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF73',
-    ':10D0C00DFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF63',
-    ':10D0D00DFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF53',
-    ':10D0E00DFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF43',
-    ':10D0F00DFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF33',
-    ':020000040007F3',
-    ':0120000DFDD5',
+    ":020000040006F4",
+    ":10D0000DFE26076D61696E2E70795468697320690B",
+    ":10D0100D73206120736C696768746C79206C6F6E16",
+    ":10D0200D67657220626974206F6620746573742061",
+    ":10D0300D746861742073686F756C64206265206D0F",
+    ":10D0400D6F7265207468616E20612073696E676C04",
+    ":10D0500D6520626C6F636B0A546869732069732075",
+    ":10D0600D6120736C696768746C79206C6F6E67658D",
+    ":10D0700D7220626974206F66207465737420740267",
+    ":10D0800D016861742073686F756C64206265206D32",
+    ":10D0900D6F7265207468616E20612073696E676CB4",
+    ":10D0A00D6520626C6F636BFFFFFFFFFFFFFFFFFFEC",
+    ":10D0B00DFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF73",
+    ":10D0C00DFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF63",
+    ":10D0D00DFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF53",
+    ":10D0E00DFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF43",
+    ":10D0F00DFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF33",
+    ":020000040007F3",
+    ":0120000DFDD5",
 ]
 TEST_SCRIPT_FS_V2_HEX_PADDING_LIST = [
-    ':1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4',
-    ':1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4',
-    ':1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4',
-    ':1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4',
-    ':1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4',
-    ':0900000CFFFFFFFFFFFFFFFFFFF4',
-    ':0600000CFFFFFFFFFFFFF4',
+    ":1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4",
+    ":1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4",
+    ":1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4",
+    ":1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4",
+    ":1000000CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF4",
+    ":0900000CFFFFFFFFFFFFFFFFFFF4",
+    ":0600000CFFFFFFFFFFFFF4",
 ]
 TEST_UNIVERSAL_HEX_LIST = [
     # Section for V1 starts
-    ':020000040000FA',
-    ':0400000A9900C0DEBB',
-    ':1000000000400020218E01005D8E01005F8E010006',
-    ':1000100000000000000000000000000000000000E0',
-    ':10002000000000000000000000000000618E0100E0',
-    ':020000040001F9',
-    ':1000000003D13000F8BD4010F3E7331D0122180082',
-    ':10001000F8F7B2FD4460EFE7E4B30200F0B5070083',
-    ':1000200089B000201E000D00019215F0ECFB0E4B74',
-    ':10003000040007609F4203D1042302791343037134',
-    ':0888B00095880100C1000000E1',
+    ":020000040000FA",
+    ":0400000A9900C0DEBB",
+    ":1000000000400020218E01005D8E01005F8E010006",
+    ":1000100000000000000000000000000000000000E0",
+    ":10002000000000000000000000000000618E0100E0",
+    ":020000040001F9",
+    ":1000000003D13000F8BD4010F3E7331D0122180082",
+    ":10001000F8F7B2FD4460EFE7E4B30200F0B5070083",
+    ":1000200089B000201E000D00019215F0ECFB0E4B74",
+    ":10003000040007609F4203D1042302791343037134",
+    ":0888B00095880100C1000000E1",
     # V1 UICR
-    ':020000041000EA',
-    ':1010C0007CB0EE17FFFFFFFF0A0000000000E30006',
-    ':0C10D000FFFFFFFF2D6D0300000000007B',
+    ":020000041000EA",
+    ":1010C0007CB0EE17FFFFFFFF0A0000000000E30006",
+    ":0C10D000FFFFFFFF2D6D0300000000007B",
     # Section for V2 starts
-    ':020000040000FA',
-    ':0400000A9903C0DEB8',
-    ':1000000D00040020810A000015070000610A0000AD',
-    ':1000100D1F07000029070000330700000000000043',
-    ':1000200D000000000000000000000000A50A000014',
-    ':1000300D3D070000000000004707000051070000C9',
+    ":020000040000FA",
+    ":0400000A9903C0DEB8",
+    ":1000000D00040020810A000015070000610A0000AD",
+    ":1000100D1F07000029070000330700000000000043",
+    ":1000200D000000000000000000000000A50A000014",
+    ":1000300D3D070000000000004707000051070000C9",
     # V2 UICR
-    ':020000041000EA',
-    ':0810140D0070070000E0070069',
+    ":020000041000EA",
+    ":0810140D0070070000E0070069",
     # V2 Regions table (this in flash again)
-    ':020000040006F4',
-    ':102FC00D0100010000B00100000000000000000041',
-    ':102FD00D02021C00E46504009CA105000000000035',
-    ':102FE00D03006D0000600000000000000000000004',
-    ':102FF00DFE307F590100300003000C009DD7B1C198',
-    ':00000001FF',
-    ''
+    ":020000040006F4",
+    ":102FC00D0100010000B00100000000000000000041",
+    ":102FD00D02021C00E46504009CA105000000000035",
+    ":102FE00D03006D0000600000000000000000000004",
+    ":102FF00DFE307F590100300003000C009DD7B1C198",
+    ":00000001FF",
+    "",
 ]
 TEST_UHEX_V1_INSERTION_INDEX = 11
 TEST_UHEX_V2_INSERTION_INDEX = 20
@@ -141,7 +145,7 @@ def test_get_version():
     Ensure a call to get_version returns the expected string.
     """
     result = uflash.get_version()
-    assert result == '.'.join([str(i) for i in uflash._VERSION])
+    assert result == ".".join([str(i) for i in uflash._VERSION])
 
 
 def test_unhexlify():
@@ -150,39 +154,44 @@ def test_unhexlify():
     result is a properly decoded string.
     """
     unhexlified = uflash.unhexlify(TEST_SCRIPT_HEXLIFIED)
-    assert unhexlified == TEST_SCRIPT.decode('utf-8')
+    assert unhexlified == TEST_SCRIPT.decode("utf-8")
 
 
 def test_unhexlify_not_python():
     """
     Test that the MicroPython script start format is present.
     """
-    assert '' == uflash.unhexlify(
-           ':020000040003F7\n:10E000000000000000000000000000000000000010')
+    assert "" == uflash.unhexlify(
+        ":020000040003F7\n:10E000000000000000000000000000000000000010"
+    )
 
 
 def test_unhexlify_bad_unicode():
     """
     Test that invalid Unicode is dealt gracefully returning an empty string.
     """
-    assert '' == uflash.unhexlify(
-           ':020000040003F7\n:10E000004D50FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF')
+    assert "" == uflash.unhexlify(
+        ":020000040003F7\n:10E000004D50FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+    )
 
 
 def test_extract():
     """
     The script should be returned as a string (if there is one).
     """
-    v1_hex = '020000040000FA\n' + \
-        ':1000000000400020218E01005D8E01005F8E010006\n' + \
-        TEST_SCRIPT_HEXLIFIED + '\n' + \
-        ':020000041000EA\n' + \
-        ':1010C0007CB0EE17FFFFFFFF0A0000000000E30006\n' + \
-        ':0C10D000FFFFFFFF2D6D0300000000007B\n' + \
-        ':0400000500018E2147\n' + \
-        ':00000001FF\n'
+    v1_hex = (
+        "020000040000FA\n"
+        + ":1000000000400020218E01005D8E01005F8E010006\n"
+        + TEST_SCRIPT_HEXLIFIED
+        + "\n"
+        + ":020000041000EA\n"
+        + ":1010C0007CB0EE17FFFFFFFF0A0000000000E30006\n"
+        + ":0C10D000FFFFFFFF2D6D0300000000007B\n"
+        + ":0400000500018E2147\n"
+        + ":00000001FF\n"
+    )
     extracted = uflash.extract_script(v1_hex)
-    assert extracted == TEST_SCRIPT.decode('utf-8')
+    assert extracted == TEST_SCRIPT.decode("utf-8")
 
 
 def test_extract_sandwiched():
@@ -190,31 +199,33 @@ def test_extract_sandwiched():
     The script hex is packed with additional data above and bellow and should
     still be returned as a the original string only.
     """
-    python_hex_lines = TEST_SCRIPT_HEXLIFIED.split('\n')
+    python_hex_lines = TEST_SCRIPT_HEXLIFIED.split("\n")
     python_sandwiched = [
         python_hex_lines[0],
-        ':10DFE000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF41',
-        '\n'.join(python_hex_lines[1:]),
-        ':10E50000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF1B',
-        ''
+        ":10DFE000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF41",
+        "\n".join(python_hex_lines[1:]),
+        ":10E50000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF1B",
+        "",
     ]
-    v1_hex_sandiwtched_data = '020000040000FA\n' + \
-        ':1000000000400020218E01005D8E01005F8E010006\n' + \
-        '\n'.join(python_sandwiched) + \
-        ':020000041000EA\n' + \
-        ':1010C0007CB0EE17FFFFFFFF0A0000000000E30006\n' + \
-        ':0C10D000FFFFFFFF2D6D0300000000007B\n' + \
-        ':0400000500018E2147\n' + \
-        ':00000001FF\n'
+    v1_hex_sandiwtched_data = (
+        "020000040000FA\n"
+        + ":1000000000400020218E01005D8E01005F8E010006\n"
+        + "\n".join(python_sandwiched)
+        + ":020000041000EA\n"
+        + ":1010C0007CB0EE17FFFFFFFF0A0000000000E30006\n"
+        + ":0C10D000FFFFFFFF2D6D0300000000007B\n"
+        + ":0400000500018E2147\n"
+        + ":00000001FF\n"
+    )
     extracted = uflash.extract_script(v1_hex_sandiwtched_data)
-    assert extracted == TEST_SCRIPT.decode('utf-8')
+    assert extracted == TEST_SCRIPT.decode("utf-8")
 
 
 def test_extract_not_valid_hex():
     """
     Return a sensible message if the hex file isn't valid
     """
-    assert uflash.extract_script('invalid input') == ''
+    assert uflash.extract_script("invalid input") == ""
 
 
 def test_extract_no_python():
@@ -222,14 +233,16 @@ def test_extract_no_python():
     Ensure that if there's no Python in the input hex then just return an empty
     (False) string.
     """
-    v1_hex_no_py_code = '020000040000FA\n' + \
-        ':1000000000400020218E01005D8E01005F8E010006\n' + \
-        ':020000041000EA\n' + \
-        ':1010C0007CB0EE17FFFFFFFF0A0000000000E30006\n' + \
-        ':0C10D000FFFFFFFF2D6D0300000000007B\n' + \
-        ':0400000500018E2147\n' + \
-        ':00000001FF\n'
-    assert uflash.extract_script(v1_hex_no_py_code) == ''
+    v1_hex_no_py_code = (
+        "020000040000FA\n"
+        + ":1000000000400020218E01005D8E01005F8E010006\n"
+        + ":020000041000EA\n"
+        + ":1010C0007CB0EE17FFFFFFFF0A0000000000E30006\n"
+        + ":0C10D000FFFFFFFF2D6D0300000000007B\n"
+        + ":0400000500018E2147\n"
+        + ":00000001FF\n"
+    )
+    assert uflash.extract_script(v1_hex_no_py_code) == ""
 
 
 def test_find_microbit_posix_exists():
@@ -237,11 +250,11 @@ def test_find_microbit_posix_exists():
     Simulate being on os.name == 'posix' and a call to "mount" returns a
     record indicating a connected micro:bit device.
     """
-    with open('tests/mount_exists.txt', 'rb') as fixture_file:
+    with open("tests/mount_exists.txt", "rb") as fixture_file:
         fixture = fixture_file.read()
-        with mock.patch('os.name', 'posix'):
-            with mock.patch('uflash.check_output', return_value=fixture):
-                assert uflash.find_microbit() == '/media/ntoll/MICROBIT'
+        with mock.patch("os.name", "posix"):
+            with mock.patch("uflash.check_output", return_value=fixture):
+                assert uflash.find_microbit() == "/media/ntoll/MICROBIT"
 
 
 def test_find_microbit_posix_missing():
@@ -249,10 +262,10 @@ def test_find_microbit_posix_missing():
     Simulate being on os.name == 'posix' and a call to "mount" returns a
     no records associated with a micro:bit device.
     """
-    with open('tests/mount_missing.txt', 'rb') as fixture_file:
+    with open("tests/mount_missing.txt", "rb") as fixture_file:
         fixture = fixture_file.read()
-        with mock.patch('os.name', 'posix'):
-            with mock.patch('uflash.check_output', return_value=fixture):
+        with mock.patch("os.name", "posix"):
+            with mock.patch("uflash.check_output", return_value=fixture):
                 assert uflash.find_microbit() is None
 
 
@@ -270,13 +283,14 @@ def test_find_microbit_nt_exists():
     #
     mock_windll.kernel32.GetDriveTypeW = mock.MagicMock()
     mock_windll.kernel32.GetDriveTypeW.return_value = 2
-    with mock.patch('os.name', 'nt'):
-        with mock.patch('os.path.exists', return_value=True):
-            return_value = ctypes.create_unicode_buffer('MICROBIT')
-            with mock.patch('ctypes.create_unicode_buffer',
-                            return_value=return_value):
+    with mock.patch("os.name", "nt"):
+        with mock.patch("os.path.exists", return_value=True):
+            return_value = ctypes.create_unicode_buffer("MICROBIT")
+            with mock.patch(
+                "ctypes.create_unicode_buffer", return_value=return_value
+            ):
                 ctypes.windll = mock_windll
-                assert uflash.find_microbit() == 'A:\\'
+                assert uflash.find_microbit() == "A:\\"
 
 
 def test_find_microbit_nt_missing():
@@ -288,11 +302,12 @@ def test_find_microbit_nt_missing():
     mock_windll.kernel32 = mock.MagicMock()
     mock_windll.kernel32.GetVolumeInformationW = mock.MagicMock()
     mock_windll.kernel32.GetVolumeInformationW.return_value = None
-    with mock.patch('os.name', 'nt'):
-        with mock.patch('os.path.exists', return_value=True):
+    with mock.patch("os.name", "nt"):
+        with mock.patch("os.path.exists", return_value=True):
             return_value = ctypes.create_unicode_buffer(1024)
-            with mock.patch('ctypes.create_unicode_buffer',
-                            return_value=return_value):
+            with mock.patch(
+                "ctypes.create_unicode_buffer", return_value=return_value
+            ):
                 ctypes.windll = mock_windll
                 assert uflash.find_microbit() is None
 
@@ -306,6 +321,7 @@ def test_find_microbit_nt_removable_only():
     Have every drive claim to be a micro:bit, but only drive B: claim
     to be removable
     """
+
     def _drive_type(letter):
         if letter == "B:\\":
             return 2  # removable
@@ -318,20 +334,21 @@ def test_find_microbit_nt_removable_only():
     mock_windll.kernel32.GetVolumeInformationW.return_value = None
     mock_windll.kernel32.GetDriveTypeW = mock.MagicMock()
     mock_windll.kernel32.GetDriveTypeW.side_effect = _drive_type
-    with mock.patch('os.name', 'nt'):
-        with mock.patch('os.path.exists', return_value=True):
-            return_value = ctypes.create_unicode_buffer('MICROBIT')
-            with mock.patch('ctypes.create_unicode_buffer',
-                            return_value=return_value):
+    with mock.patch("os.name", "nt"):
+        with mock.patch("os.path.exists", return_value=True):
+            return_value = ctypes.create_unicode_buffer("MICROBIT")
+            with mock.patch(
+                "ctypes.create_unicode_buffer", return_value=return_value
+            ):
                 ctypes.windll = mock_windll
-                assert uflash.find_microbit() == 'B:\\'
+                assert uflash.find_microbit() == "B:\\"
 
 
 def test_find_microbit_unknown_os():
     """
     Raises a NotImplementedError if the host OS is not supported.
     """
-    with mock.patch('os.name', 'foo'):
+    with mock.patch("os.name", "foo"):
         with pytest.raises(NotImplementedError) as ex:
             uflash.find_microbit()
     assert ex.value.args[0] == 'OS "foo" not supported.'
@@ -342,7 +359,7 @@ def test_save_hex():
     Ensure the good case works.
     """
     # Ensure we have a temporary file to write to that doesn't already exist.
-    path_to_hex = os.path.join(tempfile.gettempdir(), 'microbit.hex')
+    path_to_hex = os.path.join(tempfile.gettempdir(), "microbit.hex")
     if os.path.exists(path_to_hex):
         os.remove(path_to_hex)
     assert not os.path.exists(path_to_hex)
@@ -361,8 +378,8 @@ def test_save_hex_no_hex():
     The function raises a ValueError if no hex content is provided.
     """
     with pytest.raises(ValueError) as ex:
-        uflash.save_hex('', 'foo')
-    assert ex.value.args[0] == 'Cannot flash an empty .hex file.'
+        uflash.save_hex("", "foo")
+    assert ex.value.args[0] == "Cannot flash an empty .hex file."
 
 
 def test_save_hex_path_not_to_hex_file():
@@ -370,8 +387,8 @@ def test_save_hex_path_not_to_hex_file():
     The function raises a ValueError if the path is NOT to a .hex file.
     """
     with pytest.raises(ValueError) as ex:
-        uflash.save_hex('foo', '')
-    assert ex.value.args[0] == 'The path to flash must be for a .hex file.'
+        uflash.save_hex("foo", "")
+    assert ex.value.args[0] == "The path to flash must be for a .hex file."
 
 
 def test_flash_no_args():
@@ -382,12 +399,12 @@ def test_flash_no_args():
     If no path to a Python script is supplied then just flash the unmodified
     MicroPython firmware onto the device.
     """
-    with mock.patch('uflash.find_microbit', return_value='foo'):
-        with mock.patch('uflash.save_hex') as mock_save:
+    with mock.patch("uflash.find_microbit", return_value="foo"):
+        with mock.patch("uflash.save_hex") as mock_save:
             uflash.flash()
             assert mock_save.call_count == 1
             assert mock_save.call_args[0][0] == uflash._RUNTIME
-            expected_path = os.path.join('foo', 'micropython.hex')
+            expected_path = os.path.join("foo", "micropython.hex")
             assert mock_save.call_args[0][1] == expected_path
 
 
@@ -398,17 +415,17 @@ def test_flash_has_python_no_path_to_microbit():
 
     The resulting payload should be a correctly created micropython.hex file.
     """
-    with mock.patch('uflash.find_microbit', return_value='foo'):
-        with mock.patch('uflash.save_hex') as mock_save:
-            uflash.flash('tests/example.py')
+    with mock.patch("uflash.find_microbit", return_value="foo"):
+        with mock.patch("uflash.save_hex") as mock_save:
+            uflash.flash("tests/example.py")
             assert mock_save.call_count == 1
             # Create the hex we're expecting to flash onto the device.
-            with open('tests/example.py', 'rb') as py_file:
+            with open("tests/example.py", "rb") as py_file:
                 py_code = py_file.read()
             assert py_code
             expected_hex = uflash.embed_fs_uhex(uflash._RUNTIME, py_code)
             assert mock_save.call_args[0][0] == expected_hex
-            expected_path = os.path.join('foo', 'micropython.hex')
+            expected_path = os.path.join("foo", "micropython.hex")
             assert mock_save.call_args[0][1] == expected_path
 
 
@@ -417,21 +434,21 @@ def test_flash_with_path_to_multiple_microbits():
     Flash the referenced paths to the micro:bit with a hex file generated from
     the MicroPython firmware and the referenced Python script.
     """
-    with mock.patch('uflash.save_hex') as mock_save:
-        uflash.flash('tests/example.py', ['test_path1', 'test_path2'])
+    with mock.patch("uflash.save_hex") as mock_save:
+        uflash.flash("tests/example.py", ["test_path1", "test_path2"])
         assert mock_save.call_count == 2
         # Create the hex we're expecting to flash onto the device.
-        with open('tests/example.py', 'rb') as py_file:
+        with open("tests/example.py", "rb") as py_file:
             py_code = py_file.read()
         assert py_code
         expected_hex = uflash.embed_fs_uhex(uflash._RUNTIME, py_code)
 
         assert mock_save.call_args_list[0][0][0] == expected_hex
-        expected_path = os.path.join('test_path1', 'micropython.hex')
+        expected_path = os.path.join("test_path1", "micropython.hex")
         assert mock_save.call_args_list[0][0][1] == expected_path
 
         assert mock_save.call_args_list[1][0][0] == expected_hex
-        expected_path = os.path.join('test_path2', 'micropython.hex')
+        expected_path = os.path.join("test_path2", "micropython.hex")
         assert mock_save.call_args_list[1][0][1] == expected_path
 
 
@@ -440,16 +457,16 @@ def test_flash_with_path_to_microbit():
     Flash the referenced path to the micro:bit with a hex file generated from
     the MicroPython firmware and the referenced Python script.
     """
-    with mock.patch('uflash.save_hex') as mock_save:
-        uflash.flash('tests/example.py', ['test_path'])
+    with mock.patch("uflash.save_hex") as mock_save:
+        uflash.flash("tests/example.py", ["test_path"])
         assert mock_save.call_count == 1
         # Create the hex we're expecting to flash onto the device.
-        with open('tests/example.py', 'rb') as py_file:
+        with open("tests/example.py", "rb") as py_file:
             py_code = py_file.read()
         assert py_code
         expected_hex = uflash.embed_fs_uhex(uflash._RUNTIME, py_code)
         assert mock_save.call_args[0][0] == expected_hex
-        expected_path = os.path.join('test_path', 'micropython.hex')
+        expected_path = os.path.join("test_path", "micropython.hex")
         assert mock_save.call_args[0][1] == expected_path
 
 
@@ -459,16 +476,16 @@ def test_flash_with_keepname():
     the MicroPython firmware and the referenced Python script and keep the
     original filename root.
     """
-    with mock.patch('uflash.save_hex') as mock_save:
-        uflash.flash('tests/example.py', ['test_path'], keepname=True)
+    with mock.patch("uflash.save_hex") as mock_save:
+        uflash.flash("tests/example.py", ["test_path"], keepname=True)
         assert mock_save.call_count == 1
         # Create the hex we're expecting to flash onto the device.
-        with open('tests/example.py', 'rb') as py_file:
+        with open("tests/example.py", "rb") as py_file:
             py_code = py_file.read()
         assert py_code
         expected_hex = uflash.embed_fs_uhex(uflash._RUNTIME, py_code)
         assert mock_save.call_args[0][0] == expected_hex
-        expected_path = os.path.join('test_path', 'example.hex')
+        expected_path = os.path.join("test_path", "example.hex")
         assert mock_save.call_args[0][1] == expected_path
 
 
@@ -476,11 +493,12 @@ def test_main_keepname_message(capsys):
     """
     Ensure that the correct message appears when called as from py2hex.
     """
-    uflash.flash('tests/example.py', paths_to_microbits=['tests'],
-                 keepname=True)
+    uflash.flash(
+        "tests/example.py", paths_to_microbits=["tests"], keepname=True
+    )
     stdout, stderr = capsys.readouterr()
-    expected = 'Hexifying example.py as: {}'.format(
-        os.path.join('tests', 'example.hex')
+    expected = "Hexifying example.py as: {}".format(
+        os.path.join("tests", "example.hex")
     )
     assert (expected in stdout) or (expected in stderr)
 
@@ -490,10 +508,10 @@ def test_flash_with_python_script():
     If a byte representation of a Python script is passed into the function it
     should hexlify that.
     """
-    python_script = b'import this'
-    with mock.patch('uflash.save_hex'):
-        with mock.patch('uflash.find_microbit', return_value='bar'):
-            with mock.patch('uflash.embed_fs_uhex') as mock_embed_fs_uhex:
+    python_script = b"import this"
+    with mock.patch("uflash.save_hex"):
+        with mock.patch("uflash.find_microbit", return_value="bar"):
+            with mock.patch("uflash.embed_fs_uhex") as mock_embed_fs_uhex:
                 uflash.flash(python_script=python_script)
                 mock_embed_fs_uhex.assert_called_once_with(
                     uflash._RUNTIME, python_script
@@ -504,10 +522,10 @@ def test_flash_cannot_find_microbit():
     """
     Ensure an IOError is raised if it is not possible to find the micro:bit.
     """
-    with mock.patch('uflash.find_microbit', return_value=None):
+    with mock.patch("uflash.find_microbit", return_value=None):
         with pytest.raises(IOError) as ex:
             uflash.flash()
-        expected = 'Unable to find micro:bit. Is it plugged in?'
+        expected = "Unable to find micro:bit. Is it plugged in?"
     assert ex.value.args[0] == expected
 
 
@@ -518,9 +536,9 @@ def test_flash_wrong_python():
     """
     for version in [(2, 6, 3), (3, 2, 0)]:
         with pytest.raises(RuntimeError) as ex:
-            with mock.patch('sys.version_info', version):
+            with mock.patch("sys.version_info", version):
                 uflash.flash()
-            assert 'Will only run on Python ' in ex.value.args[0]
+            assert "Will only run on Python " in ex.value.args[0]
 
 
 def test_main_no_args():
@@ -528,12 +546,17 @@ def test_main_no_args():
     If there are no args into the main function, it simply calls flash with
     no arguments.
     """
-    with mock.patch('sys.argv', ['uflash', ]):
-        with mock.patch('uflash.flash') as mock_flash:
+    with mock.patch(
+        "sys.argv",
+        [
+            "uflash",
+        ],
+    ):
+        with mock.patch("uflash.flash") as mock_flash:
             uflash.main()
-            mock_flash.assert_called_once_with(path_to_python=None,
-                                               paths_to_microbits=[],
-                                               keepname=False)
+            mock_flash.assert_called_once_with(
+                path_to_python=None, paths_to_microbits=[], keepname=False
+            )
 
 
 def test_main_first_arg_python():
@@ -541,11 +564,11 @@ def test_main_first_arg_python():
     If there is a single argument that ends with ".py", it calls flash with
     it as the path to the source Python file.
     """
-    with mock.patch('uflash.flash') as mock_flash:
-        uflash.main(argv=['foo.py'])
-        mock_flash.assert_called_once_with(path_to_python='foo.py',
-                                           paths_to_microbits=[],
-                                           keepname=False)
+    with mock.patch("uflash.flash") as mock_flash:
+        uflash.main(argv=["foo.py"])
+        mock_flash.assert_called_once_with(
+            path_to_python="foo.py", paths_to_microbits=[], keepname=False
+        )
 
 
 def test_main_first_arg_help(capsys):
@@ -553,12 +576,12 @@ def test_main_first_arg_help(capsys):
     If there is a single argument of "--help", it prints some help and exits.
     """
     with pytest.raises(SystemExit):
-        uflash.main(argv=['--help'])
+        uflash.main(argv=["--help"])
 
     stdout, _ = capsys.readouterr()
     # argparse manipulates the help text (e.g. changes line wrap)
     # so it isn't trivial to compare the output to uflash._HELP_TEXT.
-    expected = 'Flash Python onto the BBC micro:bit'
+    expected = "Flash Python onto the BBC micro:bit"
     assert expected in stdout
 
 
@@ -568,7 +591,7 @@ def test_main_first_arg_version(capsys):
     and exits.
     """
     with pytest.raises(SystemExit):
-        uflash.main(argv=['--version'])
+        uflash.main(argv=["--version"])
 
     stdout, stderr = capsys.readouterr()
     expected = uflash.get_version()
@@ -583,7 +606,7 @@ def test_main_first_arg_not_python(capsys):
     error message.
     """
     with pytest.raises(SystemExit):
-        uflash.main(argv=['foo.bar'])
+        uflash.main(argv=["foo.bar"])
 
     _, stderr = capsys.readouterr()
     expected = 'Python files must end in ".py".'
@@ -594,12 +617,12 @@ def test_flash_raises(capsys):
     """
     If the flash system goes wrong, it should say that's what happened
     """
-    with mock.patch('uflash.flash', side_effect=RuntimeError("boom")):
+    with mock.patch("uflash.flash", side_effect=RuntimeError("boom")):
         with pytest.raises(SystemExit):
-            uflash.main(argv=['test.py'])
+            uflash.main(argv=["test.py"])
 
     _, stderr = capsys.readouterr()
-    expected = 'Error flashing test.py'
+    expected = "Error flashing test.py"
     assert expected in stderr
 
 
@@ -607,28 +630,28 @@ def test_flash_raises_with_info(capsys):
     """
     When flash goes wrong it should mention everything you tell it
     """
-    with mock.patch('uflash.flash', side_effect=RuntimeError("boom")):
+    with mock.patch("uflash.flash", side_effect=RuntimeError("boom")):
         with pytest.raises(SystemExit):
-            uflash.main(argv=['test.py'])
+            uflash.main(argv=["test.py"])
 
     _, stderr = capsys.readouterr()
-    expected = 'Error flashing test.py to microbit: boom\n'
+    expected = "Error flashing test.py to microbit: boom\n"
     assert stderr == expected
 
-    with mock.patch('uflash.flash', side_effect=RuntimeError("boom")):
+    with mock.patch("uflash.flash", side_effect=RuntimeError("boom")):
         with pytest.raises(SystemExit):
-            uflash.main(argv=['test.py', 'D:\\'])
+            uflash.main(argv=["test.py", "D:\\"])
 
     _, stderr = capsys.readouterr()
-    expected = 'Error flashing test.py to ' + repr(['D:\\']) + ': boom\n'
+    expected = "Error flashing test.py to " + repr(["D:\\"]) + ": boom\n"
     assert stderr == expected
 
-    with mock.patch('uflash.flash', side_effect=RuntimeError("boom")):
+    with mock.patch("uflash.flash", side_effect=RuntimeError("boom")):
         with pytest.raises(SystemExit):
-            uflash.main(argv=['test.py', 'D:\\'])
+            uflash.main(argv=["test.py", "D:\\"])
 
     _, stderr = capsys.readouterr()
-    expected = 'Error flashing test.py to ' + repr(['D:\\']) + ': boom\n'
+    expected = "Error flashing test.py to " + repr(["D:\\"]) + ": boom\n"
     assert stderr == expected
 
 
@@ -636,12 +659,12 @@ def test_watch_raises(capsys):
     """
     If the watch system goes wrong, it should say that's what happened
     """
-    with mock.patch('uflash.watch_file', side_effect=RuntimeError("boom")):
+    with mock.patch("uflash.watch_file", side_effect=RuntimeError("boom")):
         with pytest.raises(SystemExit):
-            uflash.main(argv=['--watch', 'test.py'])
+            uflash.main(argv=["--watch", "test.py"])
 
     _, stderr = capsys.readouterr()
-    expected = 'Error watching test.py'
+    expected = "Error watching test.py"
     assert expected in stderr
 
 
@@ -650,7 +673,7 @@ def test_runtime_not_implemented(capsys):
     Raises a NotImplementedError when trying to use the runtime flag.
     """
     with pytest.raises(NotImplementedError):
-        uflash.main(argv=['--runtime', 'test.hex'])
+        uflash.main(argv=["--runtime", "test.hex"])
         _, stderr = capsys.readouterr()
         assert "The 'runtime' flag is no longer supported." in stderr
 
@@ -660,7 +683,7 @@ def test_extract_not_implemented(capsys):
     Raises a NotImplementedError when trying to use the extract flag.
     """
     with pytest.raises(NotImplementedError):
-        uflash.main(argv=['--extract', 'test.py'])
+        uflash.main(argv=["--extract", "test.py"])
         _, stderr = capsys.readouterr()
         assert "The 'extract' flag is no longer supported." in stderr
 
@@ -669,13 +692,15 @@ def test_minify_arg(capsys):
     """
     Test a the minify flag print an error but doesn't raise an exception.
     """
-    with mock.patch('uflash.flash') as mock_flash:
-        uflash.main(argv=['tests/example.py', '-m'])
+    with mock.patch("uflash.flash") as mock_flash:
+        uflash.main(argv=["tests/example.py", "-m"])
         _, stderr = capsys.readouterr()
         assert "The 'minify' flag is no longer supported, ignoring" in stderr
-        mock_flash.assert_called_once_with(path_to_python='tests/example.py',
-                                           paths_to_microbits=[],
-                                           keepname=False)
+        mock_flash.assert_called_once_with(
+            path_to_python="tests/example.py",
+            paths_to_microbits=[],
+            keepname=False,
+        )
 
 
 def test_main_two_args():
@@ -683,12 +708,13 @@ def test_main_two_args():
     If there are two arguments passed into main, then it should pass them onto
     the flash() function.
     """
-    with mock.patch('uflash.flash', return_value=None) as mock_flash:
-        uflash.main(argv=['foo.py', '/media/foo/bar'])
+    with mock.patch("uflash.flash", return_value=None) as mock_flash:
+        uflash.main(argv=["foo.py", "/media/foo/bar"])
         mock_flash.assert_called_once_with(
-            path_to_python='foo.py',
-            paths_to_microbits=['/media/foo/bar'],
-            keepname=False)
+            path_to_python="foo.py",
+            paths_to_microbits=["/media/foo/bar"],
+            keepname=False,
+        )
 
 
 def test_main_multiple_microbits():
@@ -696,26 +722,35 @@ def test_main_multiple_microbits():
     If there are more than two arguments passed into main, then it should pass
     them onto the flash() function.
     """
-    with mock.patch('uflash.flash', return_value=None) as mock_flash:
-        uflash.main(argv=[
-            'foo.py', '/media/foo/bar', '/media/foo/baz', '/media/foo/bob'])
+    with mock.patch("uflash.flash", return_value=None) as mock_flash:
+        uflash.main(
+            argv=[
+                "foo.py",
+                "/media/foo/bar",
+                "/media/foo/baz",
+                "/media/foo/bob",
+            ]
+        )
         mock_flash.assert_called_once_with(
-            path_to_python='foo.py',
+            path_to_python="foo.py",
             paths_to_microbits=[
-                '/media/foo/bar', '/media/foo/baz', '/media/foo/bob'],
-            keepname=False)
+                "/media/foo/bar",
+                "/media/foo/baz",
+                "/media/foo/bob",
+            ],
+            keepname=False,
+        )
 
 
 def test_main_watch_flag():
     """
     The watch flag cause a call the correct function.
     """
-    with mock.patch('uflash.watch_file') as mock_watch_file:
-        uflash.main(argv=['-w'])
-        mock_watch_file.assert_called_once_with(None,
-                                                uflash.flash,
-                                                path_to_python=None,
-                                                paths_to_microbits=[])
+    with mock.patch("uflash.watch_file") as mock_watch_file:
+        uflash.main(argv=["-w"])
+        mock_watch_file.assert_called_once_with(
+            None, uflash.flash, path_to_python=None, paths_to_microbits=[]
+        )
 
 
 def test_watch_no_source():
@@ -726,8 +761,8 @@ def test_watch_no_source():
         uflash.watch_file(None, lambda: "should never be called!")
 
 
-@mock.patch('uflash.time')
-@mock.patch('uflash.os')
+@mock.patch("uflash.time")
+@mock.patch("uflash.os")
 def test_watch_file(mock_os, mock_time):
     """
     Make sure that the callback is called each time the file changes.
@@ -746,8 +781,7 @@ def test_watch_file(mock_os, mock_time):
     # os.path.getmtime. Start with initial value of 0.
     mock_os.path.getmtime.return_value = 0
 
-    t = threading.Thread(target=uflash.watch_file,
-                         args=('path/to/file', func))
+    t = threading.Thread(target=uflash.watch_file, args=("path/to/file", func))
     t.start()
     time.sleep(0.01)
     mock_os.path.getmtime.return_value = 1  # Simulate file change
@@ -763,35 +797,41 @@ def test_py2hex_one_arg():
     """
     Test a simple call to main().
     """
-    with mock.patch('uflash.flash') as mock_flash:
-        uflash.py2hex(argv=['tests/example.py'])
-        mock_flash.assert_called_once_with(path_to_python='tests/example.py',
-                                           paths_to_microbits=['tests'],
-                                           keepname=True)
+    with mock.patch("uflash.flash") as mock_flash:
+        uflash.py2hex(argv=["tests/example.py"])
+        mock_flash.assert_called_once_with(
+            path_to_python="tests/example.py",
+            paths_to_microbits=["tests"],
+            keepname=True,
+        )
 
 
 def test_py2hex_minify_arg(capsys):
     """
     Test a simple call to main().
     """
-    with mock.patch('uflash.flash') as mock_flash:
-        uflash.py2hex(argv=['tests/example.py', '-m'])
+    with mock.patch("uflash.flash") as mock_flash:
+        uflash.py2hex(argv=["tests/example.py", "-m"])
         _, stderr = capsys.readouterr()
         assert "The 'minify' flag is no longer supported, ignoring" in stderr
-        mock_flash.assert_called_once_with(path_to_python='tests/example.py',
-                                           paths_to_microbits=['tests'],
-                                           keepname=True)
+        mock_flash.assert_called_once_with(
+            path_to_python="tests/example.py",
+            paths_to_microbits=["tests"],
+            keepname=True,
+        )
 
 
 def test_py2hex_outdir_arg():
     """
     Test a simple call to main().
     """
-    with mock.patch('uflash.flash') as mock_flash:
-        uflash.py2hex(argv=['tests/example.py', '-o', '/tmp'])
-        mock_flash.assert_called_once_with(path_to_python='tests/example.py',
-                                           paths_to_microbits=['/tmp'],
-                                           keepname=True)
+    with mock.patch("uflash.flash") as mock_flash:
+        uflash.py2hex(argv=["tests/example.py", "-o", "/tmp"])
+        mock_flash.assert_called_once_with(
+            path_to_python="tests/example.py",
+            paths_to_microbits=["/tmp"],
+            keepname=True,
+        )
 
 
 def test_py2hex_runtime_not_implemented(capsys):
@@ -800,7 +840,7 @@ def test_py2hex_runtime_not_implemented(capsys):
     py2hex command.
     """
     with pytest.raises(NotImplementedError):
-        uflash.py2hex(argv=['--runtime', 'test.hex'])
+        uflash.py2hex(argv=["--runtime", "test.hex"])
         _, stderr = capsys.readouterr()
         assert "The 'runtime' flag is no longer supported." in stderr
 
@@ -809,12 +849,14 @@ def test_bytes_to_ihex():
     """
     Test bytes_to_ihex golden path for V1.
     """
-    data = b'A' * 32
-    expected_result = '\n'.join([
-        ':020000040003F7',
-        ':108C10004141414141414141414141414141414144',
-        ':108C20004141414141414141414141414141414134',
-    ])
+    data = b"A" * 32
+    expected_result = "\n".join(
+        [
+            ":020000040003F7",
+            ":108C10004141414141414141414141414141414144",
+            ":108C20004141414141414141414141414141414134",
+        ]
+    )
 
     result = uflash.bytes_to_ihex(0x38C10, data, universal_data_record=False)
 
@@ -825,12 +867,14 @@ def test_bytes_to_ihex_universal():
     """
     Test bytes_to_ihex golden path for V2.
     """
-    data = b'A' * 32
-    expected_result = '\n'.join([
-        ':020000040003F7',
-        ':108C100D4141414141414141414141414141414137',
-        ':108C200D4141414141414141414141414141414127',
-    ])
+    data = b"A" * 32
+    expected_result = "\n".join(
+        [
+            ":020000040003F7",
+            ":108C100D4141414141414141414141414141414137",
+            ":108C200D4141414141414141414141414141414127",
+        ]
+    )
 
     result = uflash.bytes_to_ihex(0x38C10, data, universal_data_record=True)
 
@@ -841,13 +885,15 @@ def test_bytes_to_ihex_inner_extended_linear_address_record():
     """
     Test bytes_to_ihex golden path for V2.
     """
-    data = b'A' * 32
-    expected_result = '\n'.join([
-        ':020000040003F7',
-        ':10FFF00D41414141414141414141414141414141E4',
-        ':020000040004F6',
-        ':1000000D41414141414141414141414141414141D3',
-    ])
+    data = b"A" * 32
+    expected_result = "\n".join(
+        [
+            ":020000040003F7",
+            ":10FFF00D41414141414141414141414141414141E4",
+            ":020000040004F6",
+            ":1000000D41414141414141414141414141414141D3",
+        ]
+    )
 
     result = uflash.bytes_to_ihex(0x3FFF0, data, universal_data_record=True)
 
@@ -858,39 +904,42 @@ def test_script_to_fs():
     """
     Test script_to_fs with a random example without anything special about it.
     """
-    script = b'A' * 364
-    expected_result = '\n'.join([
-        ':020000040003F7',
-        ':108C0000FE79076D61696E2E7079414141414141A4',
-        ':108C10004141414141414141414141414141414144',
-        ':108C20004141414141414141414141414141414134',
-        ':108C30004141414141414141414141414141414124',
-        ':108C40004141414141414141414141414141414114',
-        ':108C50004141414141414141414141414141414104',
-        ':108C600041414141414141414141414141414141F4',
-        ':108C70004141414141414141414141414141410223',
-        ':108C80000141414141414141414141414141414114',
-        ':108C900041414141414141414141414141414141C4',
-        ':108CA00041414141414141414141414141414141B4',
-        ':108CB00041414141414141414141414141414141A4',
-        ':108CC0004141414141414141414141414141414194',
-        ':108CD0004141414141414141414141414141414184',
-        ':108CE0004141414141414141414141414141414174',
-        ':108CF00041414141414141414141414141414103A2',
-        ':108D00000241414141414141414141414141414192',
-        ':108D10004141414141414141414141414141414143',
-        ':108D20004141414141414141414141414141414133',
-        ':108D30004141414141414141414141414141414123',
-        ':108D40004141414141414141414141414141414113',
-        ':108D50004141414141414141414141414141414103',
-        ':108D600041414141414141414141414141414141F3',
-        ':108D700041414141414141414141FFFFFFFFFFFF6F',
-        ':01F80000FD0A',
-        '',
-    ])
+    script = b"A" * 364
+    expected_result = "\n".join(
+        [
+            ":020000040003F7",
+            ":108C0000FE79076D61696E2E7079414141414141A4",
+            ":108C10004141414141414141414141414141414144",
+            ":108C20004141414141414141414141414141414134",
+            ":108C30004141414141414141414141414141414124",
+            ":108C40004141414141414141414141414141414114",
+            ":108C50004141414141414141414141414141414104",
+            ":108C600041414141414141414141414141414141F4",
+            ":108C70004141414141414141414141414141410223",
+            ":108C80000141414141414141414141414141414114",
+            ":108C900041414141414141414141414141414141C4",
+            ":108CA00041414141414141414141414141414141B4",
+            ":108CB00041414141414141414141414141414141A4",
+            ":108CC0004141414141414141414141414141414194",
+            ":108CD0004141414141414141414141414141414184",
+            ":108CE0004141414141414141414141414141414174",
+            ":108CF00041414141414141414141414141414103A2",
+            ":108D00000241414141414141414141414141414192",
+            ":108D10004141414141414141414141414141414143",
+            ":108D20004141414141414141414141414141414133",
+            ":108D30004141414141414141414141414141414123",
+            ":108D40004141414141414141414141414141414113",
+            ":108D50004141414141414141414141414141414103",
+            ":108D600041414141414141414141414141414141F3",
+            ":108D700041414141414141414141FFFFFFFFFFFF6F",
+            ":01F80000FD0A",
+            "",
+        ]
+    )
 
-    with mock.patch('uflash._FS_START_ADDR_V1', 0x38C00), \
-            mock.patch('uflash._FS_END_ADDR_V1', 0x3F800):
+    with mock.patch("uflash._FS_START_ADDR_V1", 0x38C00), mock.patch(
+        "uflash._FS_END_ADDR_V1", 0x3F800
+    ):
         result = uflash.script_to_fs(script, uflash._MICROBIT_ID_V1)
 
     assert result == expected_result, script
@@ -900,23 +949,26 @@ def test_script_to_fs_short():
     """
     Test script_to_fs with a script smaller than a fs chunk.
     """
-    script = b'Very short example'
-    expected_result = '\n'.join([
-        ':020000040003F7',
-        ':108C0000FE1B076D61696E2E70795665727920734F',
-        ':108C1000686F7274206578616D706C65FFFFFFFF8F',
-        ':108C2000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF54',
-        ':108C3000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF44',
-        ':108C4000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF34',
-        ':108C5000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF24',
-        ':108C6000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF14',
-        ':108C7000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF04',
-        ':01F80000FD0A',
-        '',
-    ])
+    script = b"Very short example"
+    expected_result = "\n".join(
+        [
+            ":020000040003F7",
+            ":108C0000FE1B076D61696E2E70795665727920734F",
+            ":108C1000686F7274206578616D706C65FFFFFFFF8F",
+            ":108C2000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF54",
+            ":108C3000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF44",
+            ":108C4000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF34",
+            ":108C5000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF24",
+            ":108C6000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF14",
+            ":108C7000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF04",
+            ":01F80000FD0A",
+            "",
+        ]
+    )
 
-    with mock.patch('uflash._FS_START_ADDR_V1', 0x38C00), \
-            mock.patch('uflash._FS_END_ADDR_V1', 0x3F800):
+    with mock.patch("uflash._FS_START_ADDR_V1", 0x38C00), mock.patch(
+        "uflash._FS_END_ADDR_V1", 0x3F800
+    ):
         result = uflash.script_to_fs(script, uflash._MICROBIT_ID_V1)
 
     assert result == expected_result, script
@@ -926,11 +978,12 @@ def test_script_to_fs_two_chunks():
     """
     Test script_to_fs with a script that takes two chunks for V1 and V2.
     """
-    expected_result_v1 = '\n'.join(TEST_SCRIPT_FS_V1_HEX_LIST + [''])
-    expected_result_v2 = '\n'.join(TEST_SCRIPT_FS_V2_HEX_LIST + [''])
+    expected_result_v1 = "\n".join(TEST_SCRIPT_FS_V1_HEX_LIST + [""])
+    expected_result_v2 = "\n".join(TEST_SCRIPT_FS_V2_HEX_LIST + [""])
 
-    with mock.patch('uflash._FS_START_ADDR_V1', 0x38C00), \
-            mock.patch('uflash._FS_END_ADDR_V1', 0x3F800):
+    with mock.patch("uflash._FS_START_ADDR_V1", 0x38C00), mock.patch(
+        "uflash._FS_END_ADDR_V1", 0x3F800
+    ):
         result_v1 = uflash.script_to_fs(TEST_SCRIPT_FS, uflash._MICROBIT_ID_V1)
         result_v2 = uflash.script_to_fs(TEST_SCRIPT_FS, uflash._MICROBIT_ID_V2)
 
@@ -942,70 +995,83 @@ def test_script_to_fs_chunk_boundary():
     """
     Test script_to_fs edge case with the taking exactly one chunk.
     """
-    script_short = b'This is an edge case test to fill the last byte of ' \
-                   b'the first chunk.\n' + (b'A' * 48)
-    expected_result_short = '\n'.join([
-        ':020000040003F7',
-        ':108C0000FE7D076D61696E2E707954686973206905',
-        ':108C10007320616E206564676520636173652074ED',
-        ':108C200065737420746F2066696C6C2074686520AD',
-        ':108C30006C6173742062797465206F662074686556',
-        ':108C4000206669727374206368756E6B2E0A4141E9',
-        ':108C50004141414141414141414141414141414104',
-        ':108C600041414141414141414141414141414141F4',
-        ':108C70004141414141414141414141414141FFFF68',
-        ':01F80000FD0A',
-        '',
-    ])
-    script_exact = b'This is an edge case test to fill the last byte of ' \
-                   b'the first chunk.\n' + (b'A' * 49)
-    expected_result_exact = '\n'.join([
-        ':020000040003F7',
-        ':108C0000FE00076D61696E2E707954686973206982',
-        ':108C10007320616E206564676520636173652074ED',
-        ':108C200065737420746F2066696C6C2074686520AD',
-        ':108C30006C6173742062797465206F662074686556',
-        ':108C4000206669727374206368756E6B2E0A4141E9',
-        ':108C50004141414141414141414141414141414104',
-        ':108C600041414141414141414141414141414141F4',
-        ':108C70004141414141414141414141414141410223',
-        ':108C800001FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF2',
-        ':108C9000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE4',
-        ':108CA000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4',
-        ':108CB000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC4',
-        ':108CC000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB4',
-        ':108CD000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA4',
-        ':108CE000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF94',
-        ':108CF000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF84',
-        ':01F80000FD0A',
-        '',
-    ])
-    script_large = b'This is an edge case test to fill the last byte of ' \
-                   b'the first chunk.\n' + (b'A' * 50)
-    expected_result_large = '\n'.join([
-        ':020000040003F7',
-        ':108C0000FE01076D61696E2E707954686973206981',
-        ':108C10007320616E206564676520636173652074ED',
-        ':108C200065737420746F2066696C6C2074686520AD',
-        ':108C30006C6173742062797465206F662074686556',
-        ':108C4000206669727374206368756E6B2E0A4141E9',
-        ':108C50004141414141414141414141414141414104',
-        ':108C600041414141414141414141414141414141F4',
-        ':108C70004141414141414141414141414141410223',
-        ':108C80000141FFFFFFFFFFFFFFFFFFFFFFFFFFFFB0',
-        ':108C9000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE4',
-        ':108CA000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4',
-        ':108CB000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC4',
-        ':108CC000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB4',
-        ':108CD000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA4',
-        ':108CE000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF94',
-        ':108CF000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF84',
-        ':01F80000FD0A',
-        '',
-    ])
+    script_short = (
+        b"This is an edge case test to fill the last byte of "
+        b"the first chunk.\n" + (b"A" * 48)
+    )
+    expected_result_short = "\n".join(
+        [
+            ":020000040003F7",
+            ":108C0000FE7D076D61696E2E707954686973206905",
+            ":108C10007320616E206564676520636173652074ED",
+            ":108C200065737420746F2066696C6C2074686520AD",
+            ":108C30006C6173742062797465206F662074686556",
+            ":108C4000206669727374206368756E6B2E0A4141E9",
+            ":108C50004141414141414141414141414141414104",
+            ":108C600041414141414141414141414141414141F4",
+            ":108C70004141414141414141414141414141FFFF68",
+            ":01F80000FD0A",
+            "",
+        ]
+    )
+    script_exact = (
+        b"This is an edge case test to fill the last byte of "
+        b"the first chunk.\n" + (b"A" * 49)
+    )
+    expected_result_exact = "\n".join(
+        [
+            ":020000040003F7",
+            ":108C0000FE00076D61696E2E707954686973206982",
+            ":108C10007320616E206564676520636173652074ED",
+            ":108C200065737420746F2066696C6C2074686520AD",
+            ":108C30006C6173742062797465206F662074686556",
+            ":108C4000206669727374206368756E6B2E0A4141E9",
+            ":108C50004141414141414141414141414141414104",
+            ":108C600041414141414141414141414141414141F4",
+            ":108C70004141414141414141414141414141410223",
+            ":108C800001FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF2",
+            ":108C9000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE4",
+            ":108CA000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4",
+            ":108CB000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC4",
+            ":108CC000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB4",
+            ":108CD000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA4",
+            ":108CE000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF94",
+            ":108CF000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF84",
+            ":01F80000FD0A",
+            "",
+        ]
+    )
+    script_large = (
+        b"This is an edge case test to fill the last byte of "
+        b"the first chunk.\n" + (b"A" * 50)
+    )
+    expected_result_large = "\n".join(
+        [
+            ":020000040003F7",
+            ":108C0000FE01076D61696E2E707954686973206981",
+            ":108C10007320616E206564676520636173652074ED",
+            ":108C200065737420746F2066696C6C2074686520AD",
+            ":108C30006C6173742062797465206F662074686556",
+            ":108C4000206669727374206368756E6B2E0A4141E9",
+            ":108C50004141414141414141414141414141414104",
+            ":108C600041414141414141414141414141414141F4",
+            ":108C70004141414141414141414141414141410223",
+            ":108C80000141FFFFFFFFFFFFFFFFFFFFFFFFFFFFB0",
+            ":108C9000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE4",
+            ":108CA000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD4",
+            ":108CB000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC4",
+            ":108CC000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB4",
+            ":108CD000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA4",
+            ":108CE000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF94",
+            ":108CF000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF84",
+            ":01F80000FD0A",
+            "",
+        ]
+    )
 
-    with mock.patch('uflash._FS_START_ADDR_V1', 0x38C00), \
-            mock.patch('uflash._FS_END_ADDR_V1', 0x3F800):
+    with mock.patch("uflash._FS_START_ADDR_V1", 0x38C00), mock.patch(
+        "uflash._FS_END_ADDR_V1", 0x3F800
+    ):
         result_short = uflash.script_to_fs(
             script_short, uflash._MICROBIT_ID_V1
         )
@@ -1025,33 +1091,34 @@ def test_script_to_fs_script_too_long():
     """
     Test script_to_fs when the script is too long and won't fit.
     """
-    script = (b'shouldfit' * 3023)[:-1]
+    script = (b"shouldfit" * 3023)[:-1]
     _ = uflash.script_to_fs(script, uflash._MICROBIT_ID_V1)
 
-    script += b'1'
+    script += b"1"
     with pytest.raises(ValueError) as ex:
         _ = uflash.script_to_fs(script, uflash._MICROBIT_ID_V1)
-    assert 'Python script must be less than' in ex.value.args[0]
+    assert "Python script must be less than" in ex.value.args[0]
 
 
 def test_script_to_fs_empty_code():
     """
     Test script_to_fs results an empty string if the input code is empty.
     """
-    result = uflash.script_to_fs('', uflash._MICROBIT_ID_V1)
-    assert result == ''
+    result = uflash.script_to_fs("", uflash._MICROBIT_ID_V1)
+    assert result == ""
 
 
 def test_script_to_fs_line_endings():
     """
     Test script_to_fs converts line endings before embedding script.
     """
-    script_win_lines = TEST_SCRIPT_FS.replace(b'\n', b'\r\n')
-    script_cr_lines = TEST_SCRIPT_FS.replace(b'\n', b'\r')
-    expected_result = '\n'.join(TEST_SCRIPT_FS_V1_HEX_LIST + [''])
+    script_win_lines = TEST_SCRIPT_FS.replace(b"\n", b"\r\n")
+    script_cr_lines = TEST_SCRIPT_FS.replace(b"\n", b"\r")
+    expected_result = "\n".join(TEST_SCRIPT_FS_V1_HEX_LIST + [""])
 
-    with mock.patch('uflash._FS_START_ADDR_V1', 0x38C00), \
-            mock.patch('uflash._FS_END_ADDR_V1', 0x3F800):
+    with mock.patch("uflash._FS_START_ADDR_V1", 0x38C00), mock.patch(
+        "uflash._FS_END_ADDR_V1", 0x3F800
+    ):
         result_win = uflash.script_to_fs(
             script_win_lines, uflash._MICROBIT_ID_V1
         )
@@ -1068,9 +1135,9 @@ def test_script_to_fs_unknown_microbit_id():
     Test script_to_fs when the micro:bit ID is not recognised.
     """
     with pytest.raises(ValueError) as ex:
-        _ = uflash.script_to_fs(TEST_SCRIPT_FS, '1234')
+        _ = uflash.script_to_fs(TEST_SCRIPT_FS, "1234")
 
-    assert 'Incompatible micro:bit ID found: 1234' in ex.value.args[0]
+    assert "Incompatible micro:bit ID found: 1234" in ex.value.args[0]
 
 
 def test_embed_fs_uhex():
@@ -1078,24 +1145,25 @@ def test_embed_fs_uhex():
     Test embed_fs_uhex to add the filesystem into a Universal Hex with standard
     two sections, one for V1 and one for V2.
     """
-    uhex = '\n'.join(TEST_UNIVERSAL_HEX_LIST)
+    uhex = "\n".join(TEST_UNIVERSAL_HEX_LIST)
     uhex_alignment = len(uhex) % 512
     v1_fs_i = 11
     v2_fs_i = 20
-    expected_uhex = '\n'.join(
-        TEST_UNIVERSAL_HEX_LIST[:v1_fs_i] +
-        TEST_SCRIPT_FS_V1_HEX_LIST +
-        TEST_SCRIPT_FS_V1_HEX_PADDING_LIST +
-        TEST_UNIVERSAL_HEX_LIST[v1_fs_i:v2_fs_i] +
-        TEST_SCRIPT_FS_V2_HEX_LIST +
-        TEST_SCRIPT_FS_V2_HEX_PADDING_LIST +
-        TEST_UNIVERSAL_HEX_LIST[v2_fs_i:]
+    expected_uhex = "\n".join(
+        TEST_UNIVERSAL_HEX_LIST[:v1_fs_i]
+        + TEST_SCRIPT_FS_V1_HEX_LIST
+        + TEST_SCRIPT_FS_V1_HEX_PADDING_LIST
+        + TEST_UNIVERSAL_HEX_LIST[v1_fs_i:v2_fs_i]
+        + TEST_SCRIPT_FS_V2_HEX_LIST
+        + TEST_SCRIPT_FS_V2_HEX_PADDING_LIST
+        + TEST_UNIVERSAL_HEX_LIST[v2_fs_i:]
     )
 
-    with mock.patch('uflash._FS_START_ADDR_V1', 0x38C00), \
-            mock.patch('uflash._FS_END_ADDR_V1', 0x3F800), \
-            mock.patch('uflash._FS_START_ADDR_V2', 0x6D000), \
-            mock.patch('uflash._FS_END_ADDR_V2', 0x72000):
+    with mock.patch("uflash._FS_START_ADDR_V1", 0x38C00), mock.patch(
+        "uflash._FS_END_ADDR_V1", 0x3F800
+    ), mock.patch("uflash._FS_START_ADDR_V2", 0x6D000), mock.patch(
+        "uflash._FS_END_ADDR_V2", 0x72000
+    ):
         uhex_with_fs = uflash.embed_fs_uhex(uhex, TEST_SCRIPT_FS)
 
     assert expected_uhex == uhex_with_fs
@@ -1123,10 +1191,10 @@ def test_pad_hex_records_no_padding_needed():
     Test the function doesn't pad is the string is already memory aligned.
     """
     fs_v1_hex_str = "\n".join(
-        TEST_SCRIPT_FS_V1_HEX_LIST + TEST_SCRIPT_FS_V1_HEX_PADDING_LIST + ['']
+        TEST_SCRIPT_FS_V1_HEX_LIST + TEST_SCRIPT_FS_V1_HEX_PADDING_LIST + [""]
     )
     fs_v2_hex_str = "\n".join(
-        TEST_SCRIPT_FS_V2_HEX_LIST + TEST_SCRIPT_FS_V2_HEX_PADDING_LIST + ['']
+        TEST_SCRIPT_FS_V2_HEX_LIST + TEST_SCRIPT_FS_V2_HEX_PADDING_LIST + [""]
     )
 
     padded_v1 = uflash.pad_hex_string(fs_v1_hex_str)
@@ -1141,69 +1209,70 @@ def test_pad_hex_records_no_padding_needed():
 def test_embed_fs_uhex_extra_uicr_jump_record():
     uhex_list = [
         # Section for V1 starts
-        ':020000040000FA',
-        ':0400000A9900C0DEBB',
-        ':1000000000400020218E01005D8E01005F8E010006',
-        ':1000100000000000000000000000000000000000E0',
-        ':10002000000000000000000000000000618E0100E0',
-        ':10003000040007609F4203D1042302791343037134',
-        ':0888B00095880100C1000000E1',
+        ":020000040000FA",
+        ":0400000A9900C0DEBB",
+        ":1000000000400020218E01005D8E01005F8E010006",
+        ":1000100000000000000000000000000000000000E0",
+        ":10002000000000000000000000000000618E0100E0",
+        ":10003000040007609F4203D1042302791343037134",
+        ":0888B00095880100C1000000E1",
         # V1 UICR
-        ':020000041000EA',
-        ':1010C0007CB0EE17FFFFFFFF0A0000000000E30006',
-        ':0C10D000FFFFFFFF2D6D0300000000007B',
+        ":020000041000EA",
+        ":1010C0007CB0EE17FFFFFFFF0A0000000000E30006",
+        ":0C10D000FFFFFFFF2D6D0300000000007B",
         # Section for V2 starts
-        ':020000040000FA',
-        ':0400000A9903C0DEB8',
-        ':1000000D00040020810A000015070000610A0000AD',
-        ':020000040001F9',
-        ':1000000D03D13000F8BD4010F3E7331D0122180082',
-        ':1000100DF8F7B2FD4460EFE7E4B30200F0B5070083',
-        ':1000200D89B000201E000D00019215F0ECFB0E4B74',
+        ":020000040000FA",
+        ":0400000A9903C0DEB8",
+        ":1000000D00040020810A000015070000610A0000AD",
+        ":020000040001F9",
+        ":1000000D03D13000F8BD4010F3E7331D0122180082",
+        ":1000100DF8F7B2FD4460EFE7E4B30200F0B5070083",
+        ":1000200D89B000201E000D00019215F0ECFB0E4B74",
         # V2 UICR with an extra extended linear address record
-        ':020000040000FA',
-        ':020000041000EA',
-        ':0810140D0070070000E0070069',
+        ":020000040000FA",
+        ":020000041000EA",
+        ":0810140D0070070000E0070069",
         # V2 Regions table (this in flash again)
-        ':020000040006F4',
-        ':102FC00D0100010000B00100000000000000000041',
-        ':102FD00D02021C00E46504009CA105000000000035',
-        ':102FE00D03006D0000600000000000000000000004',
-        ':102FF00DFE307F590100300003000C009DD7B1C198',
-        ':00000001FF',
-        ''
+        ":020000040006F4",
+        ":102FC00D0100010000B00100000000000000000041",
+        ":102FD00D02021C00E46504009CA105000000000035",
+        ":102FE00D03006D0000600000000000000000000004",
+        ":102FF00DFE307F590100300003000C009DD7B1C198",
+        ":00000001FF",
+        "",
     ]
-    uhex_ela_record = '\n'.join(uhex_list)
+    uhex_ela_record = "\n".join(uhex_list)
     uhex_ela_record_alignment = len(uhex_ela_record) % 512
     v1_fs_i = 7
     v2_fs_i = 17
-    expected_uhex_ela_record = '\n'.join(
-        uhex_list[:v1_fs_i] +
-        TEST_SCRIPT_FS_V1_HEX_LIST +
-        TEST_SCRIPT_FS_V1_HEX_PADDING_LIST +
-        uhex_list[v1_fs_i:v2_fs_i] +
-        TEST_SCRIPT_FS_V2_HEX_LIST +
-        TEST_SCRIPT_FS_V2_HEX_PADDING_LIST +
-        uhex_list[v2_fs_i:]
+    expected_uhex_ela_record = "\n".join(
+        uhex_list[:v1_fs_i]
+        + TEST_SCRIPT_FS_V1_HEX_LIST
+        + TEST_SCRIPT_FS_V1_HEX_PADDING_LIST
+        + uhex_list[v1_fs_i:v2_fs_i]
+        + TEST_SCRIPT_FS_V2_HEX_LIST
+        + TEST_SCRIPT_FS_V2_HEX_PADDING_LIST
+        + uhex_list[v2_fs_i:]
     )
     # Replace Extended linear Address with Segmented record
-    uhex_list[v2_fs_i] = ':020000020000FC'
-    uhex_esa_record = '\n'.join(uhex_list)
+    uhex_list[v2_fs_i] = ":020000020000FC"
+    uhex_esa_record = "\n".join(uhex_list)
     uhex_esa_record_alignment = len(uhex_esa_record) % 512
-    expected_uhex_esa_record = '\n'.join(
-        uhex_list[:v1_fs_i] +
-        TEST_SCRIPT_FS_V1_HEX_LIST +
-        TEST_SCRIPT_FS_V1_HEX_PADDING_LIST +
-        uhex_list[v1_fs_i:v2_fs_i] +
-        TEST_SCRIPT_FS_V2_HEX_LIST +
-        TEST_SCRIPT_FS_V2_HEX_PADDING_LIST +
-        uhex_list[v2_fs_i:]
+    expected_uhex_esa_record = "\n".join(
+        uhex_list[:v1_fs_i]
+        + TEST_SCRIPT_FS_V1_HEX_LIST
+        + TEST_SCRIPT_FS_V1_HEX_PADDING_LIST
+        + uhex_list[v1_fs_i:v2_fs_i]
+        + TEST_SCRIPT_FS_V2_HEX_LIST
+        + TEST_SCRIPT_FS_V2_HEX_PADDING_LIST
+        + uhex_list[v2_fs_i:]
     )
 
-    with mock.patch('uflash._FS_START_ADDR_V1', 0x38C00), \
-            mock.patch('uflash._FS_END_ADDR_V1', 0x3F800), \
-            mock.patch('uflash._FS_START_ADDR_V2', 0x6D000), \
-            mock.patch('uflash._FS_END_ADDR_V2', 0x72000):
+    with mock.patch("uflash._FS_START_ADDR_V1", 0x38C00), mock.patch(
+        "uflash._FS_END_ADDR_V1", 0x3F800
+    ), mock.patch("uflash._FS_START_ADDR_V2", 0x6D000), mock.patch(
+        "uflash._FS_END_ADDR_V2", 0x72000
+    ):
         uhex_ela_with_fs = uflash.embed_fs_uhex(
             uhex_ela_record, TEST_SCRIPT_FS
         )
@@ -1218,8 +1287,8 @@ def test_embed_fs_uhex_extra_uicr_jump_record():
 
 
 def test_embed_fs_uhex_empty_code():
-    uhex = '\n'.join(TEST_UNIVERSAL_HEX_LIST)
+    uhex = "\n".join(TEST_UNIVERSAL_HEX_LIST)
 
-    identical_uhex = uflash.embed_fs_uhex(uhex, '')
+    identical_uhex = uflash.embed_fs_uhex(uhex, "")
 
     assert identical_uhex == uhex


### PR DESCRIPTION
This is to make comparisons to the Mu version of uFlash easier to compare, as the code in Mu is already formatted this way.